### PR TITLE
Add env.example to the starter file to extract list

### DIFF
--- a/src/pipecatcloud/cli/commands/init.py
+++ b/src/pipecatcloud/cli/commands/init.py
@@ -25,6 +25,7 @@ FILES_TO_EXTRACT = {
     "pipecat-cloud-starter-main/pcc-deploy.toml",
     "pipecat-cloud-starter-main/README.md",
     "pipecat-cloud-starter-main/.gitignore",
+    "pipecat-cloud-starter-main/env.example",
     "pipecat-cloud-starter-main/local_runner.py",
 }
 


### PR DESCRIPTION
The pipecat-cloud-starter now has an `env.example` file, which needs to be downloaded by `pcc init`.