### PR TITLE
fix image pull secret error typo

### DIFF
--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -94,7 +94,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
             )
 
             if error:
-                if error == 400:
+                if error.get("code") == "400":
                     creds_exist = True
                 else:
                     API.print_error()


### PR DESCRIPTION
I believe this was the cause of `Cannot retrieve image pull secrets in this manner`
https://pluot.slack.com/archives/C07V2LX3GER/p1741728604709199