### PR TITLE
add agent server-side session arguments

### DIFF
--- a/src/pipecatcloud/__init__.py
+++ b/src/pipecatcloud/__init__.py
@@ -9,6 +9,7 @@ import sys
 
 from loguru import logger
 
+from .agent import DailySessionArguments, SessionArguments, WebSocketSessionArguments
 from .exception import (
     AgentNotHealthyError,
     AgentStartError,
@@ -25,6 +26,10 @@ logger.add(sys.stderr, level=str(os.getenv("PCC_LOG_LEVEL", "INFO")))
 
 
 __all__ = [
+    # Agent classes
+    "SessionArguments",
+    "DailySessionArguments",
+    "WebSocketSessionArguments",
     # Session classes
     "Session",
     "SessionParams",

--- a/src/pipecatcloud/agent.py
+++ b/src/pipecatcloud/agent.py
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2025, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+from typing import Any, Optional, TypedDict
+
+from fastapi import WebSocket
+from loguru import Logger
+
+
+class SessionArguments(TypedDict):
+    """Base class for common agent session arguments. The arguments are received
+    by the bot() entry point.
+
+    """
+
+    session_id: Optional[str]
+    session_logger: Optional[Logger]
+
+
+class DailySessionArguments(SessionArguments):
+    """Daily based agent session arguments. The arguments are received by the
+    bot() entry point.
+
+    """
+
+    room_url: str
+    token: str
+    body: Any
+
+
+class WebSocketSessionArguments(SessionArguments):
+    """Websocket based agent session arguments. The arguments are received by
+    the bot() entry point.
+
+    """
+
+    websocket: WebSocket


### PR DESCRIPTION
This is for the agent to be able to have a set of well-known arguments that the agent entry point (`bot()`) receives.