### PR TITLE
Make the start link clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added an export for the `PipecatSessionArguments` class.
 
+### Fixed
+
+- Fixed an issue where the link returned by `pcc agent start` was not clickable
+  in IDEs.
+
 ## [0.1.2] - 2025-03-12
 
 ### Added

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -509,4 +509,4 @@ async def start(
             if daily_room:
                 url = f"{daily_room}?t={daily_token}"
                 console.print("\nJoin your session by visiting the link below:")
-                console.print(f"[link='{url}']{url}[/link]")
+                console.print(f"[link={url}]{url}[/link]")


### PR DESCRIPTION
This works for me in VSCode. It should be possible to copy it in other IDEs, too.