### PR TITLE
Add CLI and SDK support for specifying daily room properties when starting an agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agent start` now accepts `--daily-properties` / `-p` for customizing Daily
   room settings when used with `--use-daily`.
 
+- Added `daily_room_properties` to `SessionParams` in SDK for configuring Daily
+  rooms when creating sessions.
+
 - Added an export for the `PipecatSessionArguments` class.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix an issue where custom `data` resulted in an agent not starting.
+
 - Fixed an issue where the link returned by `pcc agent start` was not clickable
   in IDEs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `agent start` now accepts `--daily-properties` / `-p` for customizing Daily
+  room settings when used with `--use-daily`.
+
 - Added an export for the `PipecatSessionArguments` class.
 
 ### Fixed

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -382,7 +382,7 @@ class _API:
 
         # Add data to payload if provided
         if data is not None:
-            payload["body"] = data
+            payload["body"] = json.loads(data)
 
         # Add Daily room properties only if use_daily is True
         if use_daily and daily_properties is not None:

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import json
 from functools import wraps
 from typing import Callable, List, Optional
 
@@ -368,13 +369,24 @@ class _API:
         return self.create_api_method(self._agents)
 
     async def _start_agent(
-        self, agent_name: str, api_key: str, use_daily: bool, data: Optional[str] = None
+        self,
+        agent_name: str,
+        api_key: str,
+        use_daily: bool,
+        data: Optional[str] = None,
+        daily_properties: Optional[str] = None,
     ) -> dict | None:
         url = f"{self.construct_api_url('start_path').format(service=agent_name)}"
 
         payload: dict = {"createDailyRoom": use_daily}
+
+        # Add data to payload if provided
         if data is not None:
             payload["body"] = data
+
+        # Add Daily room properties if provided
+        if daily_properties is not None and use_daily:
+            payload["dailyRoomProperties"] = json.loads(daily_properties)
 
         return await self._base_request(
             "POST", url, override_token=api_key, json=payload, not_found_is_empty=True

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -384,8 +384,8 @@ class _API:
         if data is not None:
             payload["body"] = data
 
-        # Add Daily room properties if provided
-        if daily_properties is not None and use_daily:
+        # Add Daily room properties only if use_daily is True
+        if use_daily and daily_properties is not None:
             payload["dailyRoomProperties"] = json.loads(daily_properties)
 
         return await self._base_request(

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -385,7 +385,7 @@ class _API:
             payload["body"] = json.loads(data)
 
         # Add Daily room properties only if use_daily is True
-        if use_daily and daily_properties is not None:
+        if use_daily and daily_properties:
             payload["dailyRoomProperties"] = json.loads(daily_properties)
 
         return await self._base_request(

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -464,6 +464,15 @@ async def start(
 
         return typer.Exit(1)
 
+    # Validate daily_properties JSON if provided
+    if use_daily and daily_properties is not None:
+        try:
+            json.loads(daily_properties)
+        except json.JSONDecodeError as e:
+            console.error(f"Invalid JSON format for Daily room properties: {daily_properties}")
+            console.print(f"[dim]JSON error: {str(e)}[/dim]")
+            return typer.Exit(1)
+
     # Confirm start request
     if not force:
         daily_props_display = daily_properties or "None"
@@ -517,6 +526,8 @@ async def start(
         )
 
         if error:
+            live.stop()
+            # Error is displayed from start_agent create_api_method wrapper
             return typer.Exit(1)
 
         live.stop()

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -465,7 +465,7 @@ async def start(
         return typer.Exit(1)
 
     # Validate daily_properties JSON if provided
-    if use_daily and daily_properties is not None:
+    if use_daily and daily_properties:
         try:
             json.loads(daily_properties)
         except json.JSONDecodeError as e:

--- a/src/pipecatcloud/session.py
+++ b/src/pipecatcloud/session.py
@@ -96,7 +96,7 @@ class Session:
 
         # Only process daily_room_properties if use_daily is True
         daily_properties_param = None
-        if self.params.use_daily and self.params.daily_room_properties is not None:
+        if self.params.use_daily and self.params.daily_room_properties:
             # Convert dictionary to JSON string
             if isinstance(self.params.daily_room_properties, dict):
                 daily_properties_param = json.dumps(self.params.daily_room_properties)

--- a/src/pipecatcloud/session.py
+++ b/src/pipecatcloud/session.py
@@ -21,10 +21,14 @@ class SessionParams:
     Args:
         data: Optional dictionary of data to pass to the agent.
         use_daily: If True, creates a Daily WebRTC room for the session.
+        daily_room_properties: Optional dictionary of properties to configure the Daily room.
+            Only used when use_daily=True. See Daily.co API documentation for available properties:
+            https://docs.daily.co/reference/rest-api/rooms/config
     """
 
     data: Optional[Dict[str, Any]] = None
     use_daily: Optional[bool] = False
+    daily_room_properties: Optional[Dict[str, Any]] = None
 
 
 class Session:
@@ -90,12 +94,23 @@ class Session:
                 # If it's already a string or other type, use as is
                 data_param = self.params.data
 
+        # Only process daily_room_properties if use_daily is True
+        daily_properties_param = None
+        if self.params.use_daily and self.params.daily_room_properties is not None:
+            # Convert dictionary to JSON string
+            if isinstance(self.params.daily_room_properties, dict):
+                daily_properties_param = json.dumps(self.params.daily_room_properties)
+            else:
+                # If it's already a string, use as is
+                daily_properties_param = self.params.daily_room_properties
+
         # Call the method similar to how the CLI does it
         result, error = await api.start_agent(
             agent_name=self.agent_name,
             api_key=self.api_key,
             use_daily=bool(self.params.use_daily),
             data=data_param,
+            daily_properties=daily_properties_param,
         )
 
         if error:


### PR DESCRIPTION
Ready for review.

- Adds daily room property support for the CLI and SDK
- Adds error handling for room property errors (JSON formatting and REST API errors we receive back from Daily)
- Fixes a 422 error when sending `data`