### PR TITLE
update dev-requirements (dependabot)

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
-build~=1.2.1
-grpcio-tools~=1.62.2
+build~=1.2.2
+grpcio-tools~=1.67.1
 pip-tools~=7.4.1
-pyright~=1.1.376
-pytest~=8.3.2
-ruff~=0.6.7
-setuptools~=72.2.0
-setuptools_scm~=8.1.0
+pyright~=1.1.402
+pytest~=8.4.1
+ruff~=0.12.1
+setuptools~=78.1.1
+setuptools_scm~=8.3.1


### PR DESCRIPTION
Closing this high vulnerability:
https://github.com/daily-co/pipecat-cloud/security/dependabot/1

Plus other dependabot updates—matches `pipecat-ai` dev-requirements versions.