### PR TITLE
Add docker command to build and push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,41 @@
+name: tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  group: build-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: 'Unit Tests'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: 'latest'
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: |
+          uv sync --group dev
+
+      - name: Test Docker commands
+        run: |
+          uv run pytest tests/test_docker_commands.py -v
+
+      # Note: test_agent_sessions.py is excluded because it requires complex
+      # API mocking for CI. These tests can be run locally with proper auth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `docker build-push` command for building, tagging, and pushing Docker
+  images. Automatically parses registry information from the `image` field in
+  `pcc-deploy.toml` and supports both Docker Hub and custom registries. Includes
+  real-time build output and helpful authentication error hints.
+
 ### Changed
 
 - `pcc init` now points to https://github.com/pipecat-ai/pipecat-quickstart.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,0 @@
-build~=1.2.2
-grpcio-tools~=1.67.1
-pip-tools~=7.4.1
-pyright~=1.1.402
-pytest~=8.4.1
-ruff~=0.12.1
-setuptools~=78.1.1
-setuptools_scm~=8.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,19 @@ dependencies = [
 [project.optional-dependencies]
 pipecat = ["pipecat-ai>=0.0.79"]
 
+[dependency-groups]
+dev = [
+    "build~=1.2.2",
+    "grpcio-tools~=1.67.1",
+    "pre-commit~=4.2.0",
+    "pyright~=1.1.402",
+    "pytest~=8.4.1",
+    "pytest-asyncio~=1.0.0",
+    "ruff~=0.12.1",
+    "setuptools~=78.1.1",
+    "setuptools_scm~=8.3.1",
+]
+
 [project.scripts]
 pcc = "pipecatcloud.__main__:main"
 pipecatcloud = "pipecatcloud.__main__:main"

--- a/src/pipecatcloud/cli/commands/docker.py
+++ b/src/pipecatcloud/cli/commands/docker.py
@@ -254,8 +254,10 @@ async def build_push(
 
     build_command = [
         "docker",
+        "buildx",
         "build",
         "--platform=linux/arm64",
+        "--load",
         *build_tags,
         ".",
     ]

--- a/src/pipecatcloud/cli/commands/docker.py
+++ b/src/pipecatcloud/cli/commands/docker.py
@@ -1,0 +1,290 @@
+#
+# Copyright (c) 2025, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import subprocess
+from enum import Enum
+from typing import Optional
+
+import typer
+from rich.panel import Panel
+
+from pipecatcloud._utils.async_utils import synchronizer
+from pipecatcloud._utils.console_utils import console
+from pipecatcloud._utils.deploy_utils import DeployConfigParams, with_deploy_config
+
+docker_cli = typer.Typer(
+    name="docker", help="Docker build and push utilities", no_args_is_help=True
+)
+
+
+class RegistryType(str, Enum):
+    DOCKERHUB = "dockerhub"
+    CUSTOM = "custom"
+
+
+def run_docker_command(command: list[str], description: str) -> bool:
+    """Run a docker command and handle output/errors."""
+    try:
+        console.print(f"[dim]{description}...[/dim]")
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
+        if result.stdout.strip():
+            console.print(f"[dim]{result.stdout.strip()}[/dim]")
+        return True
+    except subprocess.CalledProcessError as e:
+        console.error(f"Docker command failed: {' '.join(command)}")
+        if e.stdout:
+            console.print(f"[red]stdout: {e.stdout}[/red]")
+        if e.stderr:
+            console.print(f"[red]stderr: {e.stderr}[/red]")
+
+            # Provide helpful hints for common errors
+            stderr_lower = e.stderr.lower()
+            if "unauthorized" in stderr_lower or "access denied" in stderr_lower:
+                console.print(
+                    "\n[yellow]💡 Hint: You may need to authenticate with the registry:[/yellow]"
+                )
+                console.print("[yellow]   docker login[/yellow]")
+            elif "no such file or directory" in stderr_lower and "dockerfile" in stderr_lower:
+                console.print(
+                    "\n[yellow]💡 Hint: Make sure you have a Dockerfile in the current directory[/yellow]"
+                )
+            elif "denied" in stderr_lower and "push" in " ".join(command):
+                console.print(
+                    "\n[yellow]💡 Hint: Check your registry permissions and authentication[/yellow]"
+                )
+        return False
+    except FileNotFoundError:
+        console.error("Docker not found. Please ensure Docker is installed and in your PATH.")
+        return False
+
+
+def build_image_name(
+    registry_type: RegistryType, username: str, agent_name: str, registry_url: Optional[str] = None
+) -> str:
+    """Build the full image name based on registry type."""
+    if registry_type == RegistryType.DOCKERHUB:
+        return f"{username}/{agent_name}"
+    elif registry_type == RegistryType.CUSTOM:
+        if not registry_url:
+            raise ValueError("registry_url is required for custom registries")
+        return f"{registry_url}/{username}/{agent_name}"
+    else:
+        raise ValueError(f"Unsupported registry type: {registry_type}")
+
+
+@docker_cli.command(name="build-push", help="Build, tag, and push Docker image")
+@synchronizer.create_blocking
+@with_deploy_config
+async def build_push(
+    deploy_config=typer.Option(None, hidden=True),
+    agent_name: str = typer.Argument(
+        None, help="Name of the agent to build image for e.g. 'my-agent'", show_default=False
+    ),
+    registry: RegistryType = typer.Option(
+        None,
+        "--registry",
+        "-r",
+        help="Registry type to push to",
+        rich_help_panel="Registry Configuration",
+    ),
+    registry_username: str = typer.Option(
+        None,
+        "--username",
+        "-u",
+        help="Registry username",
+        rich_help_panel="Registry Configuration",
+    ),
+    registry_url: str = typer.Option(
+        None,
+        "--registry-url",
+        help="Custom registry URL (required for custom registries)",
+        rich_help_panel="Registry Configuration",
+    ),
+    version: str = typer.Option(
+        None,
+        "--version",
+        "-v",
+        help="Version tag for the image",
+        rich_help_panel="Build Configuration",
+    ),
+    no_push: bool = typer.Option(
+        False,
+        "--no-push",
+        help="Build and tag only, do not push to registry",
+        rich_help_panel="Build Configuration",
+    ),
+    no_latest: bool = typer.Option(
+        False,
+        "--no-latest",
+        help="Do not tag as 'latest'",
+        rich_help_panel="Build Configuration",
+    ),
+):
+    """Build, tag, and optionally push a Docker image for your agent."""
+
+    # Load values from deployment config file (if one exists)
+    partial_config = deploy_config or DeployConfigParams()
+    docker_config = getattr(partial_config, "docker_config", {})
+
+    # Parse image field to extract registry info (if present)
+    parsed_registry = None
+    parsed_username = None
+    parsed_agent_name = None
+    parsed_version = None
+    parsed_registry_url = None
+
+    if partial_config.image:
+        # Parse image like "markatdaily/voice-starter:0.5" or "registry.com/user/app:v1.0"
+        image_parts = partial_config.image.split("/")
+
+        if len(image_parts) == 2:
+            # Format: "username/repo:tag" (Docker Hub)
+            parsed_registry = "dockerhub"
+            parsed_username = image_parts[0]
+            repo_and_tag = image_parts[1]
+        elif len(image_parts) == 3:
+            # Format: "registry.com/username/repo:tag" (Custom registry)
+            parsed_registry = "custom"
+            parsed_registry_url = image_parts[0]
+            parsed_username = image_parts[1]
+            repo_and_tag = image_parts[2]
+        else:
+            # Just "repo:tag" - use for agent name only
+            repo_and_tag = partial_config.image
+
+        # Extract agent name and version from "repo:tag"
+        if ":" in repo_and_tag:
+            parsed_agent_name, parsed_version = repo_and_tag.split(":", 1)
+        else:
+            parsed_agent_name = repo_and_tag
+            parsed_version = "latest"
+
+    # Resolve final values with precedence: CLI args > parsed from image > docker config > defaults
+    final_agent_name = agent_name or parsed_agent_name or partial_config.agent_name
+    final_registry = registry or parsed_registry or docker_config.get("registry")
+    final_username = registry_username or parsed_username or docker_config.get("registry_username")
+    final_registry_url = registry_url or parsed_registry_url or docker_config.get("registry_url")
+    final_version = version or parsed_version or "latest"
+    final_no_latest = no_latest or not docker_config.get("auto_latest", True)
+
+    # Validate required parameters
+    if not final_agent_name:
+        console.error("Agent name is required. Provide via argument or pcc-deploy.toml")
+        return typer.Exit(1)
+
+    if not no_push:
+        if not final_registry:
+            console.error(
+                "Registry type is required when pushing. Use --registry or configure in pcc-deploy.toml"
+            )
+            return typer.Exit(1)
+
+        if not final_username:
+            console.error(
+                "Registry username is required when pushing. Use --username or configure in pcc-deploy.toml"
+            )
+            return typer.Exit(1)
+
+        if final_registry == RegistryType.CUSTOM and not final_registry_url:
+            console.error(
+                "Registry URL is required for custom registries. Use --registry-url or configure in pcc-deploy.toml"
+            )
+            return typer.Exit(1)
+
+    # Build image name
+    if no_push:
+        # For local builds, just use agent name
+        base_image_name = final_agent_name
+    else:
+        try:
+            base_image_name = build_image_name(
+                RegistryType(final_registry), final_username, final_agent_name, final_registry_url
+            )
+        except ValueError as e:
+            console.error(str(e))
+            return typer.Exit(1)
+
+    # Prepare image tags
+    version_tag = f"{base_image_name}:{final_version}"
+    latest_tag = f"{base_image_name}:latest"
+
+    # Build Docker command
+    build_tags = ["-t", version_tag]
+    if not final_no_latest:
+        build_tags.extend(["-t", latest_tag])
+
+    build_command = [
+        "docker",
+        "build",
+        "--platform=linux/arm64",
+        *build_tags,
+        ".",
+    ]
+
+    # Display build configuration
+    tags_display = [version_tag]
+    if not final_no_latest:
+        tags_display.append(latest_tag)
+
+    console.print(
+        Panel(
+            f"[bold white]Agent:[/bold white] [green]{final_agent_name}[/green]\n"
+            f"[bold white]Platform:[/bold white] [green]linux/arm64[/green]\n"
+            f"[bold white]Tags:[/bold white] [green]{', '.join(tags_display)}[/green]\n"
+            f"[bold white]Push:[/bold white] {'[red]No[/red]' if no_push else f'[green]Yes ({final_registry})[/green]'}",
+            title="Docker Build Configuration",
+            title_align="left",
+            border_style="yellow",
+        )
+    )
+
+    if not typer.confirm("Do you want to proceed with the build?", default=True):
+        console.cancel()
+        return typer.Exit()
+
+    # Execute build
+    console.print("\n[bold cyan]Building Docker image...[/bold cyan]")
+    if not run_docker_command(build_command, f"Building {final_agent_name}"):
+        return typer.Exit(1)
+
+    console.success(f"Successfully built image(s): {', '.join(tags_display)}")
+
+    # Push if requested
+    if not no_push:
+        console.print(f"\n[bold cyan]Pushing to {final_registry}...[/bold cyan]")
+
+        # Push version tag
+        if not run_docker_command(["docker", "push", version_tag], f"Pushing {version_tag}"):
+            return typer.Exit(1)
+
+        # Push latest tag if created
+        if not final_no_latest:
+            if not run_docker_command(["docker", "push", latest_tag], f"Pushing {latest_tag}"):
+                return typer.Exit(1)
+
+        pushed_tags = [version_tag]
+        if not final_no_latest:
+            pushed_tags.append(latest_tag)
+
+        console.success(f"Successfully pushed: {', '.join(pushed_tags)}")
+    else:
+        console.print("\n[yellow]Skipping push (--no-push specified)[/yellow]")
+
+    # Display next steps
+    if not no_push:
+        console.print("\n[dim]Your image is now available at:[/dim]")
+        for tag in tags_display:
+            console.print(f"  [bold]{tag}[/bold]")
+
+        console.print("\n[dim]To deploy this image, update your pcc-deploy.toml:[/dim]")
+        console.print(f'  [bold]image = "{version_tag}"[/bold]')
+        console.print("\n[dim]Then run:[/dim]")
+        console.print("  [bold]pipecatcloud deploy[/bold]")
+
+
+def create_docker_command(app: typer.Typer):
+    """Add docker command to the main CLI app."""
+    app.add_typer(docker_cli, rich_help_panel="Commands")

--- a/src/pipecatcloud/cli/entry_point.py
+++ b/src/pipecatcloud/cli/entry_point.py
@@ -13,6 +13,7 @@ from pipecatcloud._utils.console_utils import console
 from pipecatcloud.cli.commands.agent import agent_cli
 from pipecatcloud.cli.commands.auth import auth_cli
 from pipecatcloud.cli.commands.deploy import create_deploy_command
+from pipecatcloud.cli.commands.docker import create_docker_command
 from pipecatcloud.cli.commands.init import create_init_command
 from pipecatcloud.cli.commands.organizations import organization_cli
 from pipecatcloud.cli.commands.run import create_run_command
@@ -80,6 +81,7 @@ def cli(
 create_run_command(entrypoint_cli_typer)
 create_init_command(entrypoint_cli_typer)
 create_deploy_command(entrypoint_cli_typer)
+create_docker_command(entrypoint_cli_typer)
 entrypoint_cli_typer.add_typer(auth_cli, rich_help_panel="Commands")
 entrypoint_cli_typer.add_typer(organization_cli, rich_help_panel="Commands")
 entrypoint_cli_typer.add_typer(secrets_cli, rich_help_panel="Commands")

--- a/tests/test_docker_commands.py
+++ b/tests/test_docker_commands.py
@@ -1,0 +1,169 @@
+"""
+Unit tests for Docker build-push command.
+
+Tests the core functionality: image parsing, registry detection, and error handling.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from src.pipecatcloud._utils.deploy_utils import DeployConfigParams
+from src.pipecatcloud.cli.commands.docker import (
+    RegistryType,
+    _build_image_name,
+    _is_auth_error,
+    _suggest_docker_login,
+)
+
+
+class TestImageParsing:
+    """Test parsing of image names for different registry formats."""
+
+    def test_build_image_name_dockerhub(self):
+        """Test building Docker Hub image names."""
+        result = _build_image_name(RegistryType.DOCKERHUB, "my_username", "test-image")
+        assert result == "my_username/test-image"
+
+    def test_build_image_name_custom_registry(self):
+        """Test building custom registry image names."""
+        result = _build_image_name(RegistryType.CUSTOM, "myuser", "myapp", "gcr.io")
+        assert result == "gcr.io/myuser/myapp"
+
+    def test_build_image_name_custom_registry_missing_url(self):
+        """Test custom registry without URL raises error."""
+        with pytest.raises(ValueError, match="registry_url is required"):
+            _build_image_name(RegistryType.CUSTOM, "user", "app")
+
+
+class TestConfigParsing:
+    """Test parsing configuration from deploy config."""
+
+    def test_parse_dockerhub_image(self):
+        """Test parsing Docker Hub format image."""
+        # Simulate parsing "my_username/test-image:0.5"
+        image = "my_username/test-image:0.5"
+        parts = image.split("/")
+
+        assert len(parts) == 2
+        assert parts[0] == "my_username"  # username
+
+        repo_and_tag = parts[1]
+        repo, tag = repo_and_tag.split(":", 1)
+        assert repo == "test-image"
+        assert tag == "0.5"
+
+    def test_parse_custom_registry_image(self):
+        """Test parsing custom registry format image."""
+        # Simulate parsing "gcr.io/my-project/app:v1.0"
+        image = "gcr.io/my-project/app:v1.0"
+        parts = image.split("/")
+
+        assert len(parts) == 3
+        assert parts[0] == "gcr.io"  # registry URL
+        assert parts[1] == "my-project"  # username/project
+
+        repo_and_tag = parts[2]
+        repo, tag = repo_and_tag.split(":", 1)
+        assert repo == "app"
+        assert tag == "v1.0"
+
+    def test_parse_image_no_tag(self):
+        """Test parsing image without explicit tag."""
+        image = "my_username/test-image"
+        parts = image.split("/")
+
+        repo_and_tag = parts[1]
+        if ":" in repo_and_tag:
+            repo, tag = repo_and_tag.split(":", 1)
+        else:
+            repo = repo_and_tag
+            tag = "latest"
+
+        assert repo == "test-image"
+        assert tag == "latest"
+
+
+class TestErrorHandling:
+    """Test error detection and hint generation."""
+
+    def test_is_auth_error_unauthorized(self):
+        """Test detection of unauthorized error."""
+        stderr = "Error: unauthorized: authentication required"
+        assert _is_auth_error(stderr.lower()) is True
+
+    def test_is_auth_error_access_denied(self):
+        """Test detection of access denied error."""
+        stderr = "Error: access denied to repository"
+        assert _is_auth_error(stderr.lower()) is True
+
+    def test_is_auth_error_denied(self):
+        """Test detection of denied error."""
+        stderr = "denied: requested access to the resource is denied"
+        assert _is_auth_error(stderr.lower()) is True
+
+    def test_is_auth_error_false(self):
+        """Test non-auth errors are not detected as auth errors."""
+        stderr = "Error: failed to build: syntax error in Dockerfile"
+        assert _is_auth_error(stderr.lower()) is False
+
+    @patch("src.pipecatcloud.cli.commands.docker.console")
+    def test_suggest_docker_login_dockerhub(self, mock_console):
+        """Test Docker Hub login suggestion."""
+        registry_info = {"type": "dockerhub"}
+        _suggest_docker_login(registry_info)
+
+        mock_console.print.assert_any_call(
+            "\n[yellow]💡 You need to authenticate with the registry[/yellow]"
+        )
+        mock_console.print.assert_any_call("[yellow]   docker login[/yellow]")
+
+    @patch("src.pipecatcloud.cli.commands.docker.console")
+    def test_suggest_docker_login_custom_registry(self, mock_console):
+        """Test custom registry login suggestion."""
+        registry_info = {"type": "custom", "url": "gcr.io"}
+        _suggest_docker_login(registry_info)
+
+        mock_console.print.assert_any_call(
+            "\n[yellow]💡 You need to authenticate with the registry[/yellow]"
+        )
+        mock_console.print.assert_any_call("[yellow]   docker login gcr.io[/yellow]")
+
+    @patch("src.pipecatcloud.cli.commands.docker.console")
+    def test_suggest_docker_login_no_registry_info(self, mock_console):
+        """Test login suggestion with no registry info."""
+        _suggest_docker_login(None)
+
+        mock_console.print.assert_any_call(
+            "\n[yellow]💡 You need to authenticate with the registry[/yellow]"
+        )
+        mock_console.print.assert_any_call("[yellow]   docker login[/yellow]")
+
+
+class TestDeployConfigIntegration:
+    """Test integration with deploy config system."""
+
+    def test_deploy_config_with_docker_section(self):
+        """Test deploy config parses docker section correctly."""
+        config = DeployConfigParams(
+            agent_name="test-agent",
+            image="my_username/test:1.0",
+            docker_config={
+                "registry": "dockerhub",
+                "registry_username": "my_username",
+                "auto_latest": False,
+            },
+        )
+
+        assert config.agent_name == "test-agent"
+        assert config.image == "my_username/test:1.0"
+        assert config.docker_config["registry"] == "dockerhub"
+        assert config.docker_config["auto_latest"] is False
+
+    def test_deploy_config_minimal(self):
+        """Test minimal deploy config works."""
+        config = DeployConfigParams(agent_name="test-agent", image="my_username/test:1.0")
+
+        assert config.agent_name == "test-agent"
+        assert config.image == "my_username/test:1.0"
+        assert config.docker_config == {}  # Empty dict by default


### PR DESCRIPTION
A convenience wrapper around docker to build, tag, and push in a single command. Parses the pcc-deploy.toml file + optionally override with pcc-deploy.toml args or command line args.