### PR TITLE
Replace references to pipecat-cloud-starter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `pcc init` now points to https://github.com/pipecat-ai/pipecat-quickstart.
+
 ## [0.2.3] - 2025-08-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pcc auth login
 
 2. Login to your account `pcc auth login`
 
-3. (Optional): Clone the starter agent [here](https://github.com/daily-co/pipecat-cloud-starter)
+3. (Optional): Clone the quickstart repo [here](https://github.com/pipecat-ai/pipecat-quickstart)
 
 4. Build your agent `docker build --platform linux/arm64 -t your-agent-name .`
 

--- a/src/pipecatcloud/cli/commands/init.py
+++ b/src/pipecatcloud/cli/commands/init.py
@@ -19,14 +19,14 @@ from pipecatcloud.config import config
 # ----- Init
 
 FILES_TO_EXTRACT = {
-    "pipecat-cloud-starter-main/bot.py",
-    "pipecat-cloud-starter-main/Dockerfile",
-    "pipecat-cloud-starter-main/requirements.txt",
-    "pipecat-cloud-starter-main/pcc-deploy.toml",
-    "pipecat-cloud-starter-main/README.md",
-    "pipecat-cloud-starter-main/.gitignore",
-    "pipecat-cloud-starter-main/env.example",
-    "pipecat-cloud-starter-main/local_runner.py",
+    "pipecat-quickstart-main/bot.py",
+    "pipecat-quickstart-main/Dockerfile",
+    "pipecat-quickstart-main/pcc-deploy.toml",
+    "pipecat-quickstart-main/README.md",
+    "pipecat-quickstart-main/.gitignore",
+    "pipecat-quickstart-main/env.example",
+    "pipecat-quickstart-main/pyproject.toml",
+    "pipecat-quickstart-main/uv.lock",
 }
 
 

--- a/src/pipecatcloud/config.py
+++ b/src/pipecatcloud/config.py
@@ -19,7 +19,7 @@ _SETTINGS = {
     "api_host": _Setting("https://api.pipecat.daily.co"),
     "dashboard_host": _Setting("https://pipecat.daily.co"),
     "init_zip_url": _Setting(
-        "https://github.com/daily-co/pipecat-cloud-starter/archive/refs/heads/main.zip"
+        "https://github.com/pipecat-ai/pipecat-quickstart/archive/refs/heads/main.zip"
     ),
     "onboarding_path": _Setting("/v1/onboarding"),
     "login_path": _Setting("/auth/login"),


### PR DESCRIPTION
We're consolidating examples, which means one quickstart to run them all. The Pipecat Quickstart project can now be deployed via Pipecat Cloud. This update reflects that change.