### PR TITLE
Add body parameter to fallback type, WebSocketRunnerArguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a `body` parameter to the fallback type, `WebsocketRunnerArguments`.
+
 - Added `SmallWebRTCSessionManager`, a Session Manager to simplify bot creation
   in Pipecat Cloud using `SmallWebRTCTransport`.
 - Added a `SmallWebRTCSessionArguments` dataclass.

--- a/src/pipecatcloud/agent.py
+++ b/src/pipecatcloud/agent.py
@@ -63,6 +63,7 @@ except ImportError:
         """
 
         websocket: WebSocket
+        body: Any
 
     @dataclass
     class SmallWebRTCRunnerArguments(RunnerArguments):


### PR DESCRIPTION
In 0.0.85, Pipecat's runner arguments added an optional `body` parameter to the `WebsocketRunnerArguments`.

`pipecatcloud` now relies on the Pipecat types, but for now offers a fallback option if those types aren't provided. This change adds `body` to the fallback `WebsocketRunnerArguments` type.