### PR TITLE
pyproject: register as pipecat-cli extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Register pipecat cloud commands as `pipecat-cli` extensions.
+
 ## [0.2.7] - 2025-10-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dev = [
 pcc = "pipecatcloud.__main__:main"
 pipecatcloud = "pipecatcloud.__main__:main"
 
+[project.entry-points."pipecat_cli.extensions"]
+cloud = "pipecatcloud.cli.entry_point:entrypoint_cli_typer"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 


### PR DESCRIPTION
This register pipecat-cloud as a pipecat-cli extension. This allows `pipecat-cli` to load third-party extensions automatically.