### PR TITLE
Update PIPECAT_CLI_NAME to 'pipecat cloud'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- All error messages reference the Pipecat CLI (e.g. `pipecat cloud`) in place
+  of `pipecatcloud` or `pcc`.
+
 ### Fixed
 
 - Improved error handling when building a docker image on an x86 machine.

--- a/src/pipecatcloud/cli/__init__.py
+++ b/src/pipecatcloud/cli/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-PIPECAT_CLI_NAME = "pcc"
+PIPECAT_CLI_NAME = "pipecat cloud"
 PIPECAT_CREDENTIALS_PATH = "~/.config/pipecatcloud/pipecatcloud.toml"
 PIPECAT_DEPLOY_CONFIG_PATH = "pcc-deploy.toml"
 

--- a/src/pipecatcloud/cli/commands/docker.py
+++ b/src/pipecatcloud/cli/commands/docker.py
@@ -14,6 +14,7 @@ from rich.panel import Panel
 from pipecatcloud._utils.async_utils import synchronizer
 from pipecatcloud._utils.console_utils import console
 from pipecatcloud._utils.deploy_utils import DeployConfigParams, with_deploy_config
+from pipecatcloud.cli import PIPECAT_CLI_NAME
 
 docker_cli = typer.Typer(
     name="docker", help="Docker build and push utilities", no_args_is_help=True
@@ -399,7 +400,7 @@ async def build_push(
         console.print("\n[dim]To deploy this image, update your pcc-deploy.toml:[/dim]")
         console.print(f'  [bold]image = "{version_tag}"[/bold]')
         console.print("\n[dim]Then run:[/dim]")
-        console.print("  [bold]pipecat cloud deploy[/bold]")
+        console.print(f"  [bold]{PIPECAT_CLI_NAME} deploy[/bold]")
 
 
 def create_docker_command(app: typer.Typer):


### PR DESCRIPTION
The constant `PIPECAT_CLI_NAME` is used throughout the code base to refer to the base command. We're shifting to the Pipecat CLI in prep for this SDKs eventual deprecation.