### PR TITLE
feat: Add organization properties commands and optional region support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added `pcc organizations properties` commands for managing organization-level
+  configuration:
+  - `properties list` - Display current property values
+  - `properties set <name> <value>` - Update a property value
+  - `properties schema` - Show available properties with metadata and allowed values
+
+- Added `pcc organizations default-region [region]` convenience command to get or
+  set the organization's default region.
+
+### Changed
+
+- Region is now truly optional for `secrets set`, `secrets image-pull-secret`,
+  and `deploy` commands. When `--region` is not specified, the API now uses the
+  organization's configured default region instead of the CLI defaulting to
+  `us-west`. The confirmation display shows the actual region that will be used
+  (e.g., "us-west (organization default)").
+
+- Removed deprecation warnings about region defaulting to `us-west`. The
+  organization's default region is now the source of truth.
+
 ## [0.2.12] - 2025-11-26
 
 ### Added

--- a/src/pipecatcloud/config.py
+++ b/src/pipecatcloud/config.py
@@ -35,6 +35,7 @@ _SETTINGS = {
     "api_keys_path": _Setting("/v1/organizations/{org}/apiKeys"),
     "secrets_path": _Setting("/v1/organizations/{org}/secrets"),
     "regions_path": _Setting("/v1/organizations/{org}/regions"),
+    "properties_path": _Setting("/v1/organizations/{org}/properties"),
 }
 
 


### PR DESCRIPTION
Adds CLI support for managing organization properties and makes region truly optional by leveraging the API's organization default region.

Changes:
- Add properties API methods (get, schema, update)
- Add `pcc organizations properties` commands (list, set, schema)
- Add `pcc organizations default-region` convenience command
- Make region optional in secrets and deploy commands
- When region not specified, fetch and display org's default region
- Show region from API response in success messages
- Add tests for new API methods and optional region behavior
- Update CHANGELOG with new features