### PR TITLE
pass use_code param to /auth/login endpoint

### DIFF
--- a/src/pipecatcloud/cli/commands/auth.py
+++ b/src/pipecatcloud/cli/commands/auth.py
@@ -44,7 +44,7 @@ class _AuthFlow:
             async with aiohttp.ClientSession() as session:
                 url = f"{API.construct_api_url('login_path')}"
                 logger.debug(url)
-                async with session.post(url) as resp:
+                async with session.post(url, params={"use_code": "true"}) as resp:
                     if resp.status != 200:
                         raise Exception(f"Failed to start auth flow: {resp.status}")
                     data = await resp.json()


### PR DESCRIPTION
This PR updates the `auth login` command to include a query parameter `use_code=true`, which will be handled by the API in order to determine if this authentication flow requires entering a code or not.