### PR TITLE
Improve the UX for auth login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Return the session ID when starting an agent session.
 
+### Changed
+
+- Improved `auth login` UX to display authentication code and URL before opening
+  browser. Users now press Enter to open browser or 'q' to quit, ensuring the
+  authentication code is visible before browser takes focus.
+
 ## [0.2.17] - 2025-12-26
 
 ### Changed


### PR DESCRIPTION
We had feedback that finding the 6-digit code was confusing. The root cause being that the browser would open immediately after the `auth login` command. This hides the code, leaving the user to guess where to retrieve it.

Instead, we'll display all info—URL and code—as a result of auth login. The user needs to manually open the browser when they're ready. I've added the convenience of pressing Enter to open the browser or pressing `q` to quit the auth flow. The idea is tha this more guided flow will allow the user to see all info and progress to the next step once ready.

Here's quick video showing the new UX:

https://github.com/user-attachments/assets/2dc30736-8c2f-4429-a390-2ddc4fc886b9

Also, for now, I'll keep the `--headless` option as it doesn't hurt anything. It is redundant, so maybe we'll deprecate in the future.