### PR TITLE
fix: Make auth login --headless fully non-interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.20] - 2026-02-11
+
+### Fixed
+
+- Fixed `auth login --headless` to be fully non-interactive by using plain text
+  output instead of Rich terminal widgets, enabling use in environments like
+  Claude Code and CI/CD pipelines.
+
+
 ## [0.2.19] - 2026-01-27
 
 ### Added


### PR DESCRIPTION
## Summary
- Replaces Rich `Panel` and `Live` spinner widgets with plain `print()` statements when `--headless` is set, so the command works in non-interactive environments (e.g. Claude Code, CI/CD pipelines)
- Adds `flush=True` to all headless print calls to prevent stdout buffering issues when not connected to a TTY
- Non-headless interactive flow is unchanged

## Test plan
- [x] Tested `pcc auth login --headless` in terminal — clean plain text output, full auth flow works
- [x] Tested `pcc auth login` in terminal — to ensure the interactive workflow still works
- [x] Tested from within Claude Code (background bash) — output visible immediately, auth completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)