### PR TITLE
fix: Wait for new deployment to start before checking readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `deploy` command reporting success prematurely when updating an existing
-  agent. The CLI now waits for the new deployment to actually start (deployment
-  ID to change) before checking readiness, preventing false "ready" status when
-  the operator is slow to process the update.
+  agent. The CLI now uses the new `reconciledDeploymentId` field from the API to
+  verify the operator has actually processed the deployment before reporting
+  readiness, preventing false "ready" status when the operator is slow to process
+  the update.
+
+### Changed
+
+- The CLI now uses `desiredDeploymentId` (with fallback to `activeDeploymentId`)
+  and compares it against `reconciledDeploymentId` to determine deployment status.
 
 ## [0.2.20] - 2026-02-11
 


### PR DESCRIPTION
When updating an existing agent, the CLI now captures the previous deployment ID and waits for it to change before checking readiness. This prevents the CLI from reporting success based on the old deployment's ready status when the operator is slow to process updates.