### PR TITLE
Add troubleshooting section for macOS SSL certificate errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,32 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+## Troubleshooting
+
+### SSL certificate errors on macOS
+
+If `pcc auth login` fails with an SSL certificate verification error, your Python
+installation may not have access to the macOS system certificate store. This is
+common with Python installed via pyenv, conda, or the python.org installer.
+
+To diagnose:
+
+```python
+import ssl, sys, os
+print(ssl.get_default_verify_paths())
+print(os.path.realpath(sys.executable))
+```
+
+To fix, install `certifi` and point Python to its certificates:
+
+```shell
+pip install certifi
+export SSL_CERT_FILE=$(python -c "import certifi; print(certifi.where())")
+```
+
+For the python.org installer, you can also run the bundled
+`Install Certificates.command` script found in `/Applications/Python X.Y/`.
+
 ## 🛠️ Contributing
 
 ### Setup Steps


### PR DESCRIPTION
## Summary

- Adds a Troubleshooting section to the README with guidance for macOS SSL certificate verification errors during `pcc auth login`
- Provides a diagnostic snippet and two remediation paths (certifi + `SSL_CERT_FILE`, or the `Install Certificates.command` script)
- This is the documentation-only alternative to the code changes proposed in #93, which modified SSL handling in `api.py` and `auth.py`

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)