### PR TITLE
fix: resolve default org from API when using PIPECAT_TOKEN without co…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   appears under the revision line in both `pcc agent status` and during
   deploy monitoring.
 
+### Fixed
+
+- **Default organization resolution for `PIPECAT_TOKEN` auth**: The CLI now
+  automatically resolves the user's default organization from the API when
+  a token is present but no org is configured locally. Previously,
+  `PIPECAT_TOKEN` required the org to be in the config file or `PIPECAT_ORG`
+  to be set as well.
+
 ### Changed
 
 - All API requests now include a `User-Agent: PipecatCloudCLI/<version>` header,

--- a/src/pipecatcloud/_utils/auth_utils.py
+++ b/src/pipecatcloud/_utils/auth_utils.py
@@ -5,22 +5,63 @@
 #
 
 import functools
+from typing import Optional
 
+import aiohttp
+
+from pipecatcloud.__version__ import version
 from pipecatcloud._utils.console_utils import console
 from pipecatcloud.cli import PIPECAT_CLI_NAME
 from pipecatcloud.cli.config import config
 
 
+async def _resolve_default_org(token: str) -> Optional[str]:
+    """Fetch the user's default organization using the given token."""
+    from pipecatcloud.config import config as base_config
+
+    api_host = base_config.get("api_host")
+    org_path = base_config.get("organization_path")
+    url = f"{api_host}{org_path}"
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "User-Agent": f"PipecatCloudCLI/{version}",
+            },
+        ) as resp:
+            if resp.status == 200:
+                data = await resp.json()
+                organizations = data.get("organizations", [])
+                if organizations:
+                    return organizations[0]["name"]
+    return None
+
+
 def requires_login(func):
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        org = config.get("org")
+    async def wrapper(*args, **kwargs):
         token = config.get("token")
-        if org is None or token is None:
+        if token is None:
             console.error(
                 f"You are not logged in. Please run `{PIPECAT_CLI_NAME} auth login` first.",
             )
             return
-        return func(*args, **kwargs)
+
+        # When org is not set locally (e.g. PIPECAT_TOKEN without a config file),
+        # resolve the user's default organization from the API.
+        if config.get("org") is None:
+            org_name = await _resolve_default_org(token)
+            if org_name:
+                config.override_locally("org", org_name)
+            else:
+                console.error(
+                    "Could not determine your organization. "
+                    f"Set PIPECAT_ORG or run `{PIPECAT_CLI_NAME} auth login`.",
+                )
+                return
+
+        return await func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
…nfig file (PCC-726)

The requires_login decorator required both org and token to be set, but PIPECAT_TOKEN users without a config file might not always pass an org. Now the decorator auto-resolves the user's default organization from the API when org is missing, caching it in PIPECAT_ORG for the process lifetime.