### PR TITLE
CLI auth hardening: pentest report follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `--show-cli-config` now redacts `token` and `refresh_token` values in output.
+  A type prefix (e.g. `pcc_pat_****`) is shown for diagnostics. Users who need
+  raw values can read the config file directly.
+
+- `pcc auth use-pat` now reads the token from a secure hidden prompt instead of
+  a positional argument. The positional form still works but emits a deprecation
+  warning (tokens passed as arguments are visible in shell history and process
+  listings).
+
 ## [0.4.3] - 2026-04-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `pcc auth logout` no longer crashes if the credentials file is already absent.
 
+- Fixed `organizations_current()` fallback returning the wrong data shape when
+  no specific org is requested.
+
 ## [0.4.3] - 2026-04-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OAuth callback server now binds to `127.0.0.1` instead of `localhost` to
   prevent DNS rebinding attacks.
 
+### Fixed
+
+- `pcc auth logout` no longer claims "session revoked" when server-side
+  revocation was not confirmed. It now accurately reports what succeeded.
+
+- `pcc auth logout` no longer crashes if the credentials file is already absent.
+
 ## [0.4.3] - 2026-04-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   warning (tokens passed as arguments are visible in shell history and process
   listings).
 
+- OAuth callback server now binds to `127.0.0.1` instead of `localhost` to
+  prevent DNS rebinding attacks.
+
 ## [0.4.3] - 2026-04-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `organizations_current()` fallback returning the wrong data shape when
   no specific org is requested.
 
+- OIDC discovery metadata is now validated before use: issuer must match
+  expected value, endpoints must use HTTPS, and PKCE S256 support is verified
+  when advertised.
+
 ## [0.4.3] - 2026-04-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expected value, endpoints must use HTTPS, and PKCE S256 support is verified
   when advertised.
 
+- Credentials are now written atomically (write to temp file, fsync, rename)
+  to prevent corruption from interrupted writes. File permissions are
+  restrictive from creation.
+
 ## [0.4.3] - 2026-04-02
 
 ### Fixed

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -233,7 +233,10 @@ class _API:
                     return {"name": o["name"], "verbose_name": o["verboseName"]}
 
         # Default to first organization if active_org not found or not specified
-        return {"name": results["organizations"][0]["name"], "verbose_name": results["organizations"][0]["verboseName"]}
+        return {
+            "name": results["organizations"][0]["name"],
+            "verbose_name": results["organizations"][0]["verboseName"],
+        }
 
     @property
     def organizations_current(self):

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -233,7 +233,7 @@ class _API:
                     return {"name": o["name"], "verbose_name": o["verboseName"]}
 
         # Default to first organization if active_org not found or not specified
-        return {"name": results[0]["name"], "verbose_name": results[0]["verboseName"]}
+        return {"name": results["organizations"][0]["name"], "verbose_name": results["organizations"][0]["verboseName"]}
 
     @property
     def organizations_current(self):

--- a/src/pipecatcloud/cli/commands/auth.py
+++ b/src/pipecatcloud/cli/commands/auth.py
@@ -84,9 +84,7 @@ async def _fetch_oidc_discovery(issuer: str) -> dict:
 
     # RFC 8414 §3.1: issuer in metadata MUST exactly match the expected issuer.
     if doc.get("issuer") != issuer:
-        raise RuntimeError(
-            f"OIDC issuer mismatch: expected {issuer!r}, got {doc.get('issuer')!r}"
-        )
+        raise RuntimeError(f"OIDC issuer mismatch: expected {issuer!r}, got {doc.get('issuer')!r}")
 
     # Endpoints must use HTTPS to prevent credential interception.
     for key in ("authorization_endpoint", "token_endpoint"):
@@ -569,7 +567,9 @@ async def _use_pat_impl(token: str):
 @auth_cli.command(name="use-pat", help="Authenticate with a Personal Access Token")
 @synchronizer.create_blocking
 async def use_pat(
-    token: Optional[str] = typer.Argument(None, help="[deprecated] PAT as argument (leaks to shell history)"),
+    token: Optional[str] = typer.Argument(
+        None, help="[deprecated] PAT as argument (leaks to shell history)"
+    ),
 ):
     if token is not None:
         console.print(

--- a/src/pipecatcloud/cli/commands/auth.py
+++ b/src/pipecatcloud/cli/commands/auth.py
@@ -40,6 +40,7 @@ USER_AGENT = f"PipecatCloudCLI/{_cli_version}"
 # Ports to try for the localhost OAuth callback server.
 # Our audience is developers who may have services running on common ports.
 # We try a range and use the first available.
+CALLBACK_HOST = "127.0.0.1"
 CALLBACK_PORTS = [8400, 8401, 8402, 8403, 8404]
 CALLBACK_PATH = "/oauth_callback"
 
@@ -241,7 +242,7 @@ async def _start_callback_server() -> Tuple[Any, int, "asyncio.Future"]:
     # so we use a less-common range and try multiple.
     for port in CALLBACK_PORTS:
         try:
-            site = web.TCPSite(runner, "localhost", port)
+            site = web.TCPSite(runner, CALLBACK_HOST, port)
             await site.start()
             return runner, port, result_future
         except OSError:
@@ -343,7 +344,7 @@ async def login():
         console.error(str(e))
         return
 
-    redirect_uri = f"http://localhost:{port}{CALLBACK_PATH}"
+    redirect_uri = f"http://{CALLBACK_HOST}:{port}{CALLBACK_PATH}"
 
     try:
         # Generate PKCE verifier + challenge

--- a/src/pipecatcloud/cli/commands/auth.py
+++ b/src/pipecatcloud/cli/commands/auth.py
@@ -443,6 +443,7 @@ async def login():
 @requires_login
 async def logout():
     refresh_token = config.get("refresh_token")
+    revocation_succeeded = False
 
     # If this is an OAuth session, attempt server-side token revocation (PCC-678).
     # The /auth/logout endpoint proxies revocation to Clerk with the client_secret.
@@ -465,7 +466,7 @@ async def logout():
                                 "Token will expire within 24 hours.[/yellow]"
                             )
                         elif resp.ok:
-                            logger.debug("Server-side token revocation succeeded")
+                            revocation_succeeded = True
                         else:
                             logger.debug(f"Logout revocation returned {resp.status}")
             except (aiohttp.ClientError, asyncio.TimeoutError) as e:
@@ -478,8 +479,13 @@ async def logout():
     with console.status("[dim]Removing credentials...[/dim]", spinner="dots"):
         remove_user_config()
 
-    if refresh_token:
+    if revocation_succeeded:
         console.success("Logged out and session revoked.")
+    elif refresh_token:
+        console.success(
+            "Local credentials removed. Server-side revocation could not be confirmed.\n"
+            "[dim]The token will expire automatically within 24 hours.[/dim]"
+        )
     else:
         console.success(
             "User credentials for Pipecat Cloud removed. Please sign out via dashboard to fully revoke session.",

--- a/src/pipecatcloud/cli/commands/auth.py
+++ b/src/pipecatcloud/cli/commands/auth.py
@@ -64,17 +64,51 @@ async def _fetch_oauth_config() -> dict:
 
 
 async def _fetch_oidc_discovery(issuer: str) -> dict:
-    """Fetch OIDC discovery document from the OAuth issuer (RFC 8414).
+    """Fetch and validate OIDC discovery document from the OAuth issuer (RFC 8414).
 
     This gives us the authorization and token endpoints without
     hardcoding any provider-specific URLs.
+
+    Validates the discovery metadata per RFC 8414 §3.1 and RFC 9207 §2.4:
+    - issuer must exactly match the expected value
+    - authorization_endpoint and token_endpoint must use HTTPS
+    - code_challenge_methods_supported must include S256 (when present)
+    - response_types_supported must include "code" (when present)
     """
     url = f"{issuer}/.well-known/openid-configuration"
     async with aiohttp.ClientSession() as session:
         async with session.get(url, headers={"User-Agent": USER_AGENT}) as resp:
             if resp.status != 200:
                 raise RuntimeError(f"OIDC discovery failed ({resp.status}) at {url}")
-            return await resp.json()
+            doc = await resp.json()
+
+    # RFC 8414 §3.1: issuer in metadata MUST exactly match the expected issuer.
+    if doc.get("issuer") != issuer:
+        raise RuntimeError(
+            f"OIDC issuer mismatch: expected {issuer!r}, got {doc.get('issuer')!r}"
+        )
+
+    # Endpoints must use HTTPS to prevent credential interception.
+    for key in ("authorization_endpoint", "token_endpoint"):
+        endpoint = doc.get(key, "")
+        if not endpoint.startswith("https://"):
+            raise RuntimeError(f"OIDC {key} must use HTTPS, got {endpoint!r}")
+
+    # If the server advertises supported challenge methods, verify S256 is included.
+    challenge_methods = doc.get("code_challenge_methods_supported")
+    if challenge_methods is not None and "S256" not in challenge_methods:
+        raise RuntimeError(
+            f"OIDC server does not support S256 PKCE (supported: {challenge_methods})"
+        )
+
+    # If the server advertises supported response types, verify "code" is included.
+    response_types = doc.get("response_types_supported")
+    if response_types is not None and "code" not in response_types:
+        raise RuntimeError(
+            f"OIDC server does not support 'code' response type (supported: {response_types})"
+        )
+
+    return doc
 
 
 # ---- Helpers ----

--- a/src/pipecatcloud/cli/commands/auth.py
+++ b/src/pipecatcloud/cli/commands/auth.py
@@ -528,8 +528,21 @@ async def _use_pat_impl(token: str):
 @auth_cli.command(name="use-pat", help="Authenticate with a Personal Access Token")
 @synchronizer.create_blocking
 async def use_pat(
-    token: str = typer.Argument(help="Personal Access Token (pcc_pat_...)"),
+    token: Optional[str] = typer.Argument(None, help="[deprecated] PAT as argument (leaks to shell history)"),
 ):
+    if token is not None:
+        console.print(
+            "[yellow]Warning: Passing tokens as arguments is deprecated — they are visible in "
+            "shell history and process listings. Next time, omit the argument to use the "
+            "secure prompt.[/yellow]"
+        )
+    else:
+        import getpass
+
+        token = getpass.getpass("Personal Access Token: ")
+        if not token:
+            console.error("No token provided.")
+            return
     await _use_pat_impl(token)
 
 

--- a/src/pipecatcloud/cli/config.py
+++ b/src/pipecatcloud/cli/config.py
@@ -93,7 +93,10 @@ def _write_user_config(new_config):
 
 
 def remove_user_config():
-    os.remove(user_config_path)
+    try:
+        os.remove(user_config_path)
+    except FileNotFoundError:
+        pass
 
 
 def update_user_config(

--- a/src/pipecatcloud/cli/config.py
+++ b/src/pipecatcloud/cli/config.py
@@ -7,6 +7,7 @@
 import os
 import stat
 import sys
+import tempfile
 from typing import Optional
 
 import toml
@@ -80,16 +81,31 @@ user_config = _read_user_config()
 
 def _write_user_config(new_config):
     dir_path = os.path.dirname(user_config_path)
-    os.makedirs(dir_path, exist_ok=True)
+    os.makedirs(dir_path, mode=0o700, exist_ok=True)
 
-    with open(user_config_path, "w") as f:
-        toml.dump(new_config, f)
-
-    # Restrict permissions so only the file owner can access credentials.
-    # On Windows os.chmod is limited but home directories are already
-    # protected by ACLs, so this is effectively a Unix-only hardening.
-    os.chmod(dir_path, stat.S_IRWXU)  # 0o700
-    os.chmod(user_config_path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+    # Atomic write: serialize to a temp file in the same directory, fsync,
+    # then rename into place.  This prevents a crash mid-write from leaving
+    # a truncated or empty credentials file (RFC 6749 §10.3).
+    fd = None
+    tmp_path = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(dir=dir_path, prefix=".pipecatcloud_", suffix=".tmp")
+        # mkstemp opens with 0o600 by default — restrictive from creation.
+        with os.fdopen(fd, "w") as f:
+            fd = None  # os.fdopen takes ownership of the fd
+            toml.dump(new_config, f)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, user_config_path)
+        tmp_path = None  # rename succeeded, nothing to clean up
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
 
 def remove_user_config():

--- a/src/pipecatcloud/cli/entry_point.py
+++ b/src/pipecatcloud/cli/entry_point.py
@@ -42,8 +42,18 @@ def show_config_callback(value: bool):
         from pipecatcloud._utils.deploy_utils import load_deploy_config_file
         from pipecatcloud.cli.config import deploy_config_path
 
-        # Print local config
-        pprint(config.to_dict())
+        config_dict = config.to_dict()
+
+        # Redact credential values — users who need raw values can read the
+        # config file directly (~/.config/pipecatcloud/pipecatcloud.toml).
+        for key in ("token", "refresh_token"):
+            if config_dict.get(key):
+                val = str(config_dict[key])
+                # Show token type prefix (e.g. "pcc_pat_****") for diagnostics
+                prefix = val[:8] if len(val) > 12 else ""
+                config_dict[key] = f"{prefix}****"
+
+        pprint(config_dict)
 
         # Check for deploy config
         try:
@@ -76,7 +86,7 @@ def cli(
         None,
         "--show-cli-config",
         callback=show_config_callback,
-        help="Show CLI internal configuration (credentials, active org)",
+        help="Show CLI internal configuration (credentials redacted)",
     ),
 ):
     pass

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -345,3 +345,51 @@ class TestAPIProperties:
             # Verify payload
             payload = mock_request.call_args[1]["json"]
             assert payload == {"defaultRegion": "eu-central"}
+
+
+class TestOrganizationsCurrent:
+    """Test organizations_current fallback behavior."""
+
+    @pytest.fixture
+    def api_client(self):
+        return _API(token="test-token", is_cli=True)
+
+    @pytest.mark.asyncio
+    async def test_fallback_returns_first_org(self, api_client):
+        """Regression: fallback path must index into results['organizations'], not results."""
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {
+                "organizations": [
+                    {"name": "my-org", "verboseName": "My Organization"},
+                    {"name": "other-org", "verboseName": "Other Org"},
+                ]
+            }
+
+            result = await api_client._organizations_current(org=None)
+
+            assert result == {"name": "my-org", "verbose_name": "My Organization"}
+
+    @pytest.mark.asyncio
+    async def test_matching_org_returned(self, api_client):
+        """When org is specified, the matching org should be returned."""
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {
+                "organizations": [
+                    {"name": "first-org", "verboseName": "First Org"},
+                    {"name": "target-org", "verboseName": "Target Org"},
+                ]
+            }
+
+            result = await api_client._organizations_current(org="target-org")
+
+            assert result == {"name": "target-org", "verbose_name": "Target Org"}
+
+    @pytest.mark.asyncio
+    async def test_no_orgs_returns_none(self, api_client):
+        """When the user has no organizations, return None."""
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"organizations": []}
+
+            result = await api_client._organizations_current(org=None)
+
+            assert result is None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -66,9 +66,7 @@ class TestCallbackServer:
         runner, port, result_future = await _start_callback_server()
         try:
             async with __import__("aiohttp").ClientSession() as session:
-                await session.get(
-                    f"http://127.0.0.1:{port}/oauth_callback?error=access_denied"
-                )
+                await session.get(f"http://127.0.0.1:{port}/oauth_callback?error=access_denied")
             code, state = result_future.result()
             assert code is None
             assert state is None
@@ -81,9 +79,7 @@ class TestCallbackServer:
         runner, port, result_future = await _start_callback_server()
         try:
             async with __import__("aiohttp").ClientSession() as session:
-                await session.get(
-                    f"http://127.0.0.1:{port}/oauth_callback?state=test-state"
-                )
+                await session.get(f"http://127.0.0.1:{port}/oauth_callback?state=test-state")
             code, state = result_future.result()
             # code is None because query param "code" is absent
             assert code is None
@@ -145,7 +141,9 @@ class TestOIDCDiscoveryValidation:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
-        return patch("pipecatcloud.cli.commands.auth.aiohttp.ClientSession", return_value=mock_session)
+        return patch(
+            "pipecatcloud.cli.commands.auth.aiohttp.ClientSession", return_value=mock_session
+        )
 
     @pytest.mark.asyncio
     async def test_valid_document_passes(self):
@@ -217,14 +215,26 @@ class TestTokenRefresh:
             "token_endpoint": "https://auth.example.com/token",
         }
         return (
-            patch("pipecatcloud.cli.commands.auth._fetch_oauth_config", new_callable=AsyncMock, return_value=oauth_config),
-            patch("pipecatcloud.cli.commands.auth._fetch_oidc_discovery", new_callable=AsyncMock, return_value=oidc_doc),
+            patch(
+                "pipecatcloud.cli.commands.auth._fetch_oauth_config",
+                new_callable=AsyncMock,
+                return_value=oauth_config,
+            ),
+            patch(
+                "pipecatcloud.cli.commands.auth._fetch_oidc_discovery",
+                new_callable=AsyncMock,
+                return_value=oidc_doc,
+            ),
         )
 
     @pytest.mark.asyncio
     async def test_refresh_success(self):
         mock_oauth, mock_oidc = self._mock_oauth_and_oidc()
-        token_response = {"access_token": "new-token", "refresh_token": "new-refresh", "expires_in": 3600}
+        token_response = {
+            "access_token": "new-token",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        }
 
         mock_resp = AsyncMock()
         mock_resp.status = 200
@@ -238,7 +248,9 @@ class TestTokenRefresh:
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
         with mock_oauth, mock_oidc:
-            with patch("pipecatcloud.cli.commands.auth.aiohttp.ClientSession", return_value=mock_session):
+            with patch(
+                "pipecatcloud.cli.commands.auth.aiohttp.ClientSession", return_value=mock_session
+            ):
                 result = await refresh_access_token("old-refresh-token")
 
         assert result["access_token"] == "new-token"
@@ -258,7 +270,9 @@ class TestTokenRefresh:
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
         with mock_oauth, mock_oidc:
-            with patch("pipecatcloud.cli.commands.auth.aiohttp.ClientSession", return_value=mock_session):
+            with patch(
+                "pipecatcloud.cli.commands.auth.aiohttp.ClientSession", return_value=mock_session
+            ):
                 result = await refresh_access_token("bad-refresh-token")
 
         assert result is None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,289 @@
+"""
+Unit tests for auth flow internals.
+
+Covers PKCE generation, callback server edge cases, token refresh,
+discovery validation, and logout resilience.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from pipecatcloud.cli.commands.auth import (
+    _generate_code_challenge,
+    _generate_code_verifier,
+    _fetch_oidc_discovery,
+    _start_callback_server,
+    refresh_access_token,
+)
+
+
+# ---- PKCE (RFC 7636) ----
+
+
+class TestPKCE:
+    """Test PKCE code verifier and challenge generation."""
+
+    def test_rfc7636_appendix_b_vector(self):
+        """RFC 7636 Appendix B reference vector."""
+        verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        expected_challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        assert _generate_code_challenge(verifier) == expected_challenge
+
+    def test_verifier_length_in_range(self):
+        """RFC 7636 §4.1: verifier must be 43-128 characters."""
+        verifier = _generate_code_verifier()
+        assert 43 <= len(verifier) <= 128
+
+    def test_verifier_is_url_safe(self):
+        """Verifier must only contain unreserved URI characters."""
+        import re
+
+        verifier = _generate_code_verifier()
+        assert re.fullmatch(r"[A-Za-z0-9_-]+", verifier)
+
+    def test_challenge_has_no_padding(self):
+        """BASE64URL encoding must strip '=' padding per RFC 7636 §4.2."""
+        challenge = _generate_code_challenge("test-verifier-string-that-is-long-enough")
+        assert "=" not in challenge
+
+
+# ---- Callback server ----
+
+
+class TestCallbackServer:
+    """Test the localhost OAuth callback server edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_callback_error_sets_none_result(self):
+        """OAuth error in callback should resolve the future with (None, None)."""
+        runner, port, result_future = await _start_callback_server()
+        try:
+            async with __import__("aiohttp").ClientSession() as session:
+                await session.get(
+                    f"http://127.0.0.1:{port}/oauth_callback?error=access_denied"
+                )
+            code, state = result_future.result()
+            assert code is None
+            assert state is None
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_callback_missing_code_returns_none_code(self):
+        """Callback with no code or error should return (None, state)."""
+        runner, port, result_future = await _start_callback_server()
+        try:
+            async with __import__("aiohttp").ClientSession() as session:
+                await session.get(
+                    f"http://127.0.0.1:{port}/oauth_callback?state=test-state"
+                )
+            code, state = result_future.result()
+            # code is None because query param "code" is absent
+            assert code is None
+            assert state == "test-state"
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_callback_success_returns_code_and_state(self):
+        """Successful callback should return the code and state."""
+        runner, port, result_future = await _start_callback_server()
+        try:
+            async with __import__("aiohttp").ClientSession() as session:
+                await session.get(
+                    f"http://127.0.0.1:{port}/oauth_callback?code=auth-code-123&state=state-456"
+                )
+            code, state = result_future.result()
+            assert code == "auth-code-123"
+            assert state == "state-456"
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_callback_timeout(self):
+        """The future should raise TimeoutError if no callback arrives."""
+        runner, _port, result_future = await _start_callback_server()
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(result_future, timeout=0.1)
+        finally:
+            await runner.cleanup()
+
+
+# ---- Discovery validation ----
+
+
+class TestOIDCDiscoveryValidation:
+    """Test OIDC discovery metadata validation."""
+
+    def _make_valid_doc(self, issuer="https://auth.example.com"):
+        return {
+            "issuer": issuer,
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "code_challenge_methods_supported": ["S256"],
+            "response_types_supported": ["code"],
+        }
+
+    def _mock_fetch(self, doc):
+        """Create a mock aiohttp response returning the given doc."""
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=doc)
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        return patch("pipecatcloud.cli.commands.auth.aiohttp.ClientSession", return_value=mock_session)
+
+    @pytest.mark.asyncio
+    async def test_valid_document_passes(self):
+        issuer = "https://auth.example.com"
+        doc = self._make_valid_doc(issuer)
+        with self._mock_fetch(doc):
+            result = await _fetch_oidc_discovery(issuer)
+        assert result["authorization_endpoint"] == "https://auth.example.com/authorize"
+
+    @pytest.mark.asyncio
+    async def test_issuer_mismatch_raises(self):
+        doc = self._make_valid_doc("https://wrong-issuer.example.com")
+        with self._mock_fetch(doc):
+            with pytest.raises(RuntimeError, match="issuer mismatch"):
+                await _fetch_oidc_discovery("https://auth.example.com")
+
+    @pytest.mark.asyncio
+    async def test_http_endpoint_raises(self):
+        doc = self._make_valid_doc()
+        doc["token_endpoint"] = "http://auth.example.com/token"  # HTTP, not HTTPS
+        with self._mock_fetch(doc):
+            with pytest.raises(RuntimeError, match="must use HTTPS"):
+                await _fetch_oidc_discovery("https://auth.example.com")
+
+    @pytest.mark.asyncio
+    async def test_missing_s256_raises(self):
+        doc = self._make_valid_doc()
+        doc["code_challenge_methods_supported"] = ["plain"]
+        with self._mock_fetch(doc):
+            with pytest.raises(RuntimeError, match="S256"):
+                await _fetch_oidc_discovery("https://auth.example.com")
+
+    @pytest.mark.asyncio
+    async def test_missing_code_response_type_raises(self):
+        doc = self._make_valid_doc()
+        doc["response_types_supported"] = ["token"]
+        with self._mock_fetch(doc):
+            with pytest.raises(RuntimeError, match="code"):
+                await _fetch_oidc_discovery("https://auth.example.com")
+
+    @pytest.mark.asyncio
+    async def test_absent_optional_fields_passes(self):
+        """When code_challenge_methods_supported / response_types_supported
+        are absent, validation should pass (they're optional in the spec)."""
+        doc = self._make_valid_doc()
+        del doc["code_challenge_methods_supported"]
+        del doc["response_types_supported"]
+        with self._mock_fetch(doc):
+            result = await _fetch_oidc_discovery("https://auth.example.com")
+        assert result["issuer"] == "https://auth.example.com"
+
+
+# ---- Token refresh ----
+
+
+class TestTokenRefresh:
+    """Test refresh_access_token success and failure paths."""
+
+    def _mock_oauth_and_oidc(self):
+        """Patch both discovery fetches to return valid config."""
+        oauth_config = {
+            "issuer": "https://auth.example.com",
+            "client_id": "test-client-id",
+            "scopes": "openid profile",
+        }
+        oidc_doc = {
+            "issuer": "https://auth.example.com",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+        return (
+            patch("pipecatcloud.cli.commands.auth._fetch_oauth_config", new_callable=AsyncMock, return_value=oauth_config),
+            patch("pipecatcloud.cli.commands.auth._fetch_oidc_discovery", new_callable=AsyncMock, return_value=oidc_doc),
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_success(self):
+        mock_oauth, mock_oidc = self._mock_oauth_and_oidc()
+        token_response = {"access_token": "new-token", "refresh_token": "new-refresh", "expires_in": 3600}
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=token_response)
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with mock_oauth, mock_oidc:
+            with patch("pipecatcloud.cli.commands.auth.aiohttp.ClientSession", return_value=mock_session):
+                result = await refresh_access_token("old-refresh-token")
+
+        assert result["access_token"] == "new-token"
+
+    @pytest.mark.asyncio
+    async def test_refresh_failure_returns_none(self):
+        mock_oauth, mock_oidc = self._mock_oauth_and_oidc()
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 401
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with mock_oauth, mock_oidc:
+            with patch("pipecatcloud.cli.commands.auth.aiohttp.ClientSession", return_value=mock_session):
+                result = await refresh_access_token("bad-refresh-token")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_config_fetch_failure_returns_none(self):
+        with patch(
+            "pipecatcloud.cli.commands.auth._fetch_oauth_config",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("unreachable"),
+        ):
+            result = await refresh_access_token("some-refresh-token")
+
+        assert result is None
+
+
+# ---- Logout without config file ----
+
+
+class TestLogoutWithoutConfig:
+    """Test that remove_user_config is idempotent."""
+
+    def test_remove_missing_config_does_not_raise(self):
+        from pipecatcloud.cli.config import remove_user_config
+
+        with patch("pipecatcloud.cli.config.user_config_path", "/nonexistent/path/config.toml"):
+            # Should not raise
+            remove_user_config()


### PR DESCRIPTION
## Summary

Implements the CLI-side fixes from the external pentest of the OAuth2 PKCE + PAT auth flow (PCC-728). Each finding is its own commit.

- **Redact secrets in `--show-cli-config`** and move PAT entry off argv to a hidden prompt (PKCE-P1-08)
- **Bind callback server to `127.0.0.1`** instead of `localhost` to prevent DNS rebinding (PKCE-P0-26)
- **Fix logout edge cases**: idempotent config removal, accurate revocation messaging (PKCE-P0-37)
- **Fix `organizations_current()` fallback bug**: `results[0]` → `results["organizations"][0]` with regression tests
- **Validate OIDC discovery metadata**: issuer match, HTTPS endpoints, S256/code support (PKCE-P1-24)
- **Atomic credential writes**: write-fsync-rename pattern with restrictive permissions at creation (PKCE-P1-06)
- **Auth unit tests**: RFC 7636 Appendix B vector, callback edge cases, discovery validation, refresh, logout

Item 8 (expired PAT cleanup) is server-side and not included here.

### Notes

- Clerk redirect URIs for `127.0.0.1:8400-8404` have been added to both dev and prod OAuth apps. The `localhost` URIs should remain until older CLI versions age out.
- `pcc auth use-pat` still accepts positional args for backwards compat but emits a deprecation warning.

## Test plan

- [x] All 152 tests pass (21 new)
- [ ] Manual: `pcc --show-cli-config` shows redacted tokens (e.g. `pcc_pat_****`)
- [ ] Manual: `pcc auth use-pat` prompts for token when no argument given
- [ ] Manual: `pcc auth use-pat <token>` shows deprecation warning
- [ ] Manual: `pcc auth login` completes successfully with `127.0.0.1` callback
- [ ] Manual: `pcc auth logout` with unreachable API shows accurate messaging