### PR TITLE
feat!: repurpose --force on `pcc deploy` to send forceRedeploy (PCC-731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `pipecatcloud[pipecat]` optional dependency now requires `pipecat-ai>=1.0.0`
   (previously `>=0.0.79`).
 
+- **`pcc deploy --force` now forces a new deployment** even if your
+  configuration hasn't changed. Previously, `--force` only skipped the
+  confirmation prompt. Use this when you want to pick up a new image
+  behind the same tag (e.g. `:latest`) or restart your agent instances.
+  `--yes` remains available for non-interactive/CI usage.
+
 ## [0.4.4] - 2026-04-10
 
 ### Added

--- a/src/pipecatcloud/_utils/deploy_utils.py
+++ b/src/pipecatcloud/_utils/deploy_utils.py
@@ -333,6 +333,7 @@ class DeployConfigParams:
     build_config: BuildConfig = field(factory=BuildConfig)  # Cloud build configuration
     agent_profile: Optional[str] = None
     krisp_viva: KrispVivaConfig = field(factory=KrispVivaConfig)
+    force_redeploy: bool = False
 
     def __attrs_post_init__(self):
         if self.image is not None and ":" not in self.image:

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -414,6 +414,7 @@ class _API:
             "krispViva": {
                 "audioFilter": deploy_config.krisp_viva.audio_filter,
             },
+            "forceRedeploy": deploy_config.force_redeploy or None,
         }
 
         # Use either build_id (cloud build) or image (user-provided)

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -346,6 +346,10 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
         # Close the live display before starting the new polling phase
         live.stop()
 
+        # Surface API warning (e.g. when identical config was deployed without --force)
+        if result and result.get("warning"):
+            console.print(f"[yellow]Warning: {result['warning']}[/yellow]")
+
     """
     # 3. Poll status until healthy
     """
@@ -556,11 +560,11 @@ def create_deploy_command(app: typer.Typer):
             help="Region for service deployment",
             rich_help_panel="Deployment Configuration",
         ),
-        skip_confirm: bool = typer.Option(
+        force: bool = typer.Option(
             False,
             "--force",
             "-f",
-            help="Force deployment / skip confirmation",
+            help="Force a new deployment even if config hasn't changed",
             rich_help_panel="Additional Options",
         ),
         yes: bool = typer.Option(
@@ -632,7 +636,7 @@ def create_deploy_command(app: typer.Typer):
         org = organization or config.get("org")
 
         # Combine automation flags
-        auto_yes = yes or skip_confirm
+        auto_yes = yes or force
 
         # Compose deployment config from CLI options and config file (if provided)
         # Order of precedence:
@@ -653,6 +657,7 @@ def create_deploy_command(app: typer.Typer):
         )
         partial_config.enable_krisp = krisp or partial_config.enable_krisp
         partial_config.agent_profile = profile or partial_config.agent_profile
+        partial_config.force_redeploy = force
 
         # Override build config from CLI args
         if build_dir:


### PR DESCRIPTION
BREAKING CHANGE: `--force` on `pcc deploy` now forces a new deployment even if config hasn't changed, in addition to skipping confirmation. Use `--yes` for prompt-skipping only.

- Add force_redeploy field to DeployConfigParams
- Send forceRedeploy in API payload when --force is set
- Display API warning when nothingChanged heuristic triggers
- Update CHANGELOG

This is a breaking change to --force semantics; bump minor version (0.4.x -> 0.5.0) at release time.

Depends on: https://github.com/daily-co/pipecat-cloud-sandbox/pull/430