### PR TITLE
feat(cli): rename keys delete to revoke [PCC-748]

### DIFF
--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -295,18 +295,30 @@ class _API:
         """
         return self.create_api_method(self._api_key_create)
 
-    async def _api_key_delete(self, api_key_id: str, org: str) -> dict:
+    async def _api_key_revoke(self, api_key_id: str, org: str) -> dict:
         url = f"{self.construct_api_url('api_keys_path').format(org=org)}/{api_key_id}"
         return await self._base_request("DELETE", url) or {}
 
     @property
-    def api_key_delete(self):
-        """Delete API keys for an organization.
+    def api_key_revoke(self):
+        """Revoke an API key for an organization.
+
+        The server soft-deletes the key by marking it revoked; the record is
+        preserved so audit fields (e.g. lastUsedAt) remain available.
+
         Args:
-            api_key_id: Human readable name for API key
+            api_key_id: ID of the API key to revoke
             org: Organization ID
         """
-        return self.create_api_method(self._api_key_delete)
+        return self.create_api_method(self._api_key_revoke)
+
+    @property
+    def api_key_delete(self):
+        """Deprecated: use :attr:`api_key_revoke` instead.
+
+        Kept as an alias so older CLI/library callers keep working.
+        """
+        return self.create_api_method(self._api_key_revoke)
 
     # Secret
 

--- a/src/pipecatcloud/cli/commands/organizations.py
+++ b/src/pipecatcloud/cli/commands/organizations.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+from typing import Optional
+
 import questionary
 import typer
 from loguru import logger
@@ -268,17 +270,12 @@ async def create_key(
     console.success(table, subtitle="Using as default in local config")
 
 
-@keys_cli.command(name="delete", help="Delete an API key for an organization.")
-@synchronizer.create_blocking
-@requires_login
-async def delete_key(
-    organization: str = typer.Option(
-        None,
-        "--organization",
-        "-o",
-        help="Organization to get tokens for",
-    ),
-):
+async def _revoke_key_flow(organization: Optional[str]) -> None:
+    """Shared implementation for the ``revoke`` command and its ``delete`` alias.
+
+    Prompts the user to pick an active API key, clears it from local config if
+    it was the default, and asks the server to revoke it.
+    """
     org = organization or config.get("org")
 
     with console.status(
@@ -298,12 +295,23 @@ async def delete_key(
             typer.Exit(1)
             return
 
-    # Prompt user to delete a key
+    # Only offer keys that are not already revoked — revoking a revoked key
+    # is a no-op on the server and confuses the interactive flow.
+    active_keys = [k for k in data["public"] if not k.get("revoked")]
+
+    if not active_keys:
+        console.error(
+            "[bold]No active API keys to revoke.[/bold]\n"
+            "[dim]All keys in this organization are already revoked.[/dim]"
+        )
+        return typer.Exit(1)
+
+    # Prompt user to revoke a key
     key = await questionary.select(
-        "Select API key to delete",
+        "Select API key to revoke",
         choices=[
             {"name": key["metadata"]["name"], "value": (key["id"], key["key"])}
-            for key in data["public"]
+            for key in active_keys
         ],
     ).ask_async()
 
@@ -328,13 +336,49 @@ async def delete_key(
             console.error("Unable to remove default key from local user config")
             return typer.Exit(1)
 
-    with console.status(f"[dim]Deleting API key with ID {key[0]}...[/dim]", spinner="dots"):
-        data, error = await API.api_key_delete(key[0], org)
+    with console.status(f"[dim]Revoking API key with ID {key[0]}...[/dim]", spinner="dots"):
+        data, error = await API.api_key_revoke(key[0], org)
 
         if error:
             return typer.Exit(1)
 
-    console.success(f"API key with ID: [bold]'{key[0]}'[/bold] deleted successfully.")
+    console.success(f"API key with ID: [bold]'{key[0]}'[/bold] revoked successfully.")
+
+
+@keys_cli.command(name="revoke", help="Revoke an API key for an organization.")
+@synchronizer.create_blocking
+@requires_login
+async def revoke_key(
+    organization: str = typer.Option(
+        None,
+        "--organization",
+        "-o",
+        help="Organization the API key belongs to",
+    ),
+):
+    await _revoke_key_flow(organization)
+
+
+@keys_cli.command(
+    name="delete",
+    hidden=True,
+    help="Deprecated alias for 'revoke'.",
+)
+@synchronizer.create_blocking
+@requires_login
+async def delete_key(
+    organization: str = typer.Option(
+        None,
+        "--organization",
+        "-o",
+        help="Organization the API key belongs to",
+    ),
+):
+    console.print(
+        "[yellow]'delete' is deprecated and will be removed in a future release; "
+        "use 'revoke' instead.[/yellow]"
+    )
+    await _revoke_key_flow(organization)
 
 
 @keys_cli.command(name="use", help="Set default API key for an organization in local config.")


### PR DESCRIPTION
## Summary

- Renames `API.api_key_delete` to `API.api_key_revoke` and keeps `api_key_delete` as a deprecated alias.
- Renames the `pcc organizations keys delete` command to `revoke`; `delete` remains as a hidden alias that prints a deprecation warning, so existing scripts keep working for one release.
- Skips already-revoked keys in the interactive selection and errors helpfully when nothing is revokable.

## Test plan

- [x] `pcc organizations keys revoke` lists only active keys and revokes the selected one
- [x] `pcc organizations keys delete` still runs but prints the deprecation warning
- [x] Revoking the last active key shows the "no active keys" error on a second run

Ticket: https://linear.app/dailyco/issue/PCC-748/change-api-key-delete-to-revoke-soft-delete