### PR TITLE
feat: add websocket_auth support to pcc deploy (PCC-756)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `websocket_auth` config option in `pcc-deploy.toml` to control authentication
+  mode for the generic WebSocket handler (`/ws/generic`). Valid values are
+  `"none"` (no authentication required) and `"token"` (requires a session token
+  obtained via `/start`). New services default to `"token"` if not specified.
+
 ### Fixed
 
 - `.dockerignore` patterns written with Docker's conventional trailing

--- a/src/pipecatcloud/_utils/deploy_utils.py
+++ b/src/pipecatcloud/_utils/deploy_utils.py
@@ -334,6 +334,7 @@ class DeployConfigParams:
     agent_profile: Optional[str] = None
     krisp_viva: KrispVivaConfig = field(factory=KrispVivaConfig)
     force_redeploy: bool = False
+    websocket_auth: Optional[str] = None
 
     def __attrs_post_init__(self):
         if self.image is not None and ":" not in self.image:
@@ -356,6 +357,7 @@ class DeployConfigParams:
             "build_config": self.build_config.to_dict() if self.build_config else None,
             "agent_profile": self.agent_profile,
             "krisp_viva": self.krisp_viva.to_dict() if self.krisp_viva else None,
+            "websocket_auth": self.websocket_auth,
         }
 
 
@@ -415,6 +417,7 @@ def load_deploy_config_file() -> Optional[DeployConfigParams]:
             "build",
             "agent_profile",
             "krisp_viva",
+            "websocket_auth",
         }
         unexpected_keys = set(config_data.keys()) - expected_keys
         if unexpected_keys:

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -427,6 +427,7 @@ class _API:
                 "audioFilter": deploy_config.krisp_viva.audio_filter,
             },
             "forceRedeploy": deploy_config.force_redeploy or None,
+            "websocketAuth": deploy_config.websocket_auth,
         }
 
         # Use either build_id (cloud build) or image (user-provided)

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -226,6 +226,11 @@ async def status(
             krisp_viva_status,
         )
 
+        deployment_table.add_row(
+            "[bold]Krisp VIVA:[/bold]",
+            krisp_viva_status,
+        )
+
         # Autoscaling info
         autoscaling_data = data.get("autoScaling", None)
         if autoscaling_data:

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -226,11 +226,6 @@ async def status(
             krisp_viva_status,
         )
 
-        deployment_table.add_row(
-            "[bold]Krisp VIVA:[/bold]",
-            krisp_viva_status,
-        )
-
         # Autoscaling info
         autoscaling_data = data.get("autoScaling", None)
         if autoscaling_data:

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -797,6 +797,16 @@ def create_deploy_command(app: typer.Typer):
                 f"[bold white]Agent profile:[/bold white] {'[dim]None[/dim]' if not partial_config.agent_profile else '[green]' + partial_config.agent_profile + '[/green]'}",
                 f"[bold white]Krisp (deprecated):[/bold white] {'[dim]Disabled[/dim]' if not partial_config.enable_krisp else '[green]Enabled[/green]'}",
                 f"[bold white]Krisp VIVA:[/bold white] {'[dim]Disabled[/dim]' if not partial_config.krisp_viva.audio_filter else '[green]Enabled (' + partial_config.krisp_viva.audio_filter + ')[/green]'}",
+            ]
+        )
+
+        if partial_config.websocket_auth:
+            content_items.append(
+                f"[bold white]WebSocket auth:[/bold white] [green]{partial_config.websocket_auth}[/green]"
+            )
+
+        content_items.extend(
+            [
                 "\n[dim]Scaling configuration:[/dim]",
             ]
         )


### PR DESCRIPTION
Add websocket_auth config option to pcc-deploy.toml and the deploy API payload. Valid values: "none" (open access) or "token" (HMAC session token required). Omitting the field lets the API apply its default ("token" for new services, unchanged for updates).

- Add websocket_auth to DeployConfigParams and deploy payload
- Show WebSocket auth in deploy review panel when explicitly configured
- Add to CHANGELOG

Example pcc-deploy.toml:
  websocket_auth = "none"

NOTE: Requires the API-side websocketAuth support (PCC-744) to be deployed before this CLI version is released to users.