### PR TITLE
fix: remove 50-agent cap on --max-agents and --max-instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--max-session-duration` flag on `pcc deploy` for configuring the
+  per-service maximum session duration in seconds. Accepts values
+  between 60 and 14400 (4 hours), defaulting to 7200 (2 hours) when
+  unset. Also exposed in `pcc agent status` output and as
+  `max_session_duration` in `pcc-deploy.toml`.
+
 ### Fixed
 
 - `.dockerignore` patterns written with Docker's conventional trailing

--- a/src/pipecatcloud/_utils/deploy_utils.py
+++ b/src/pipecatcloud/_utils/deploy_utils.py
@@ -10,7 +10,6 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Callable, List, Optional
 
-
 import toml
 import typer
 from attr import dataclass, field
@@ -342,6 +341,8 @@ class DeployConfigParams:
         # Cannot specify both image and build_id
         if self.image is not None and self.build_id is not None:
             raise ValueError("Cannot specify both 'image' and 'build_id'")
+        if self.max_session_duration is not None and not 60 <= self.max_session_duration <= 14400:
+            raise ValueError("max_session_duration must be between 60 and 14400 seconds")
 
     def to_dict(self):
         return {
@@ -462,8 +463,10 @@ def with_deploy_config(func: Callable) -> Callable:
             deploy_config = load_deploy_config_file()
             kwargs["deploy_config"] = deploy_config
         except Exception as e:
-            logger.error(f"Error loading deploy config: {e}")
-            raise ConfigFileError(str(e))
+            from pipecatcloud._utils.console_utils import console
+
+            console.error(f"Error loading deploy config: {e}")
+            raise typer.Exit(1)
         return func(*args, **kwargs)
 
     return wrapper

--- a/src/pipecatcloud/_utils/deploy_utils.py
+++ b/src/pipecatcloud/_utils/deploy_utils.py
@@ -334,6 +334,7 @@ class DeployConfigParams:
     agent_profile: Optional[str] = None
     krisp_viva: KrispVivaConfig = field(factory=KrispVivaConfig)
     force_redeploy: bool = False
+    max_session_duration: Optional[int] = None
 
     def __attrs_post_init__(self):
         if self.image is not None and ":" not in self.image:
@@ -356,6 +357,7 @@ class DeployConfigParams:
             "build_config": self.build_config.to_dict() if self.build_config else None,
             "agent_profile": self.agent_profile,
             "krisp_viva": self.krisp_viva.to_dict() if self.krisp_viva else None,
+            "max_session_duration": self.max_session_duration,
         }
 
 
@@ -415,6 +417,7 @@ def load_deploy_config_file() -> Optional[DeployConfigParams]:
             "build",
             "agent_profile",
             "krisp_viva",
+            "max_session_duration",
         }
         unexpected_keys = set(config_data.keys()) - expected_keys
         if unexpected_keys:

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -427,6 +427,7 @@ class _API:
                 "audioFilter": deploy_config.krisp_viva.audio_filter,
             },
             "forceRedeploy": deploy_config.force_redeploy or None,
+            "maxSessionDuration": deploy_config.max_session_duration,
         }
 
         # Use either build_id (cloud build) or image (user-provided)

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -226,6 +226,20 @@ async def status(
             krisp_viva_status,
         )
 
+        # Max session duration (read from deployment manifest spec).
+        # Absent from the manifest when the user never set an explicit value —
+        # the platform applies its default via the CRD in that case.
+        max_session_duration = (
+            data.get("deployment", {})
+            .get("manifest", {})
+            .get("spec", {})
+            .get("maxSessionDurationSeconds")
+        )
+        deployment_table.add_row(
+            "[bold]Max Session Duration:[/bold]",
+            f"{max_session_duration}s" if max_session_duration is not None else "[dim]Default[/dim]",
+        )
+
         # Autoscaling info
         autoscaling_data = data.get("autoScaling", None)
         if autoscaling_data:

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -237,7 +237,9 @@ async def status(
         )
         deployment_table.add_row(
             "[bold]Max Session Duration:[/bold]",
-            f"{max_session_duration}s" if max_session_duration is not None else "[dim]Default[/dim]",
+            f"{max_session_duration}s"
+            if max_session_duration is not None
+            else "[dim]Default[/dim]",
         )
 
         # Autoscaling info

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -514,10 +514,9 @@ def create_deploy_command(app: typer.Typer):
             None,
             "--max-agents",
             "-max",
-            help="Maximum number of allowed agents",
+            help="Maximum number of allowed agents (default cap 50, contact support to raise)",
             rich_help_panel="Deployment Configuration",
             min=1,
-            max=50,
         ),
         secret_set: str = typer.Option(
             None,
@@ -624,7 +623,6 @@ def create_deploy_command(app: typer.Typer):
             help="[Deprecated] Use --max-agents instead",
             hidden=True,
             min=1,
-            max=50,
         ),
     ):
         # Handle @deprecated options

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -560,6 +560,14 @@ def create_deploy_command(app: typer.Typer):
             help="Region for service deployment",
             rich_help_panel="Deployment Configuration",
         ),
+        max_session_duration: Optional[int] = typer.Option(
+            None,
+            "--max-session-duration",
+            help="Maximum session duration in seconds (60-14400, default 7200). Sessions are terminated when this limit is reached.",
+            rich_help_panel="Deployment Configuration",
+            min=60,
+            max=14400,
+        ),
         force: bool = typer.Option(
             False,
             "--force",
@@ -658,6 +666,11 @@ def create_deploy_command(app: typer.Typer):
         partial_config.enable_krisp = krisp or partial_config.enable_krisp
         partial_config.agent_profile = profile or partial_config.agent_profile
         partial_config.force_redeploy = force
+        partial_config.max_session_duration = (
+            max_session_duration
+            if max_session_duration is not None
+            else partial_config.max_session_duration
+        )
 
         # Override build config from CLI args
         if build_dir:
@@ -797,6 +810,7 @@ def create_deploy_command(app: typer.Typer):
                 f"[bold white]Agent profile:[/bold white] {'[dim]None[/dim]' if not partial_config.agent_profile else '[green]' + partial_config.agent_profile + '[/green]'}",
                 f"[bold white]Krisp (deprecated):[/bold white] {'[dim]Disabled[/dim]' if not partial_config.enable_krisp else '[green]Enabled[/green]'}",
                 f"[bold white]Krisp VIVA:[/bold white] {'[dim]Disabled[/dim]' if not partial_config.krisp_viva.audio_filter else '[green]Enabled (' + partial_config.krisp_viva.audio_filter + ')[/green]'}",
+                f"[bold white]Max session duration:[/bold white] {'[dim]Default[/dim]' if partial_config.max_session_duration is None else '[green]' + str(partial_config.max_session_duration) + 's[/green]'}",
                 "\n[dim]Scaling configuration:[/dim]",
             ]
         )

--- a/tests/test_max_session_duration.py
+++ b/tests/test_max_session_duration.py
@@ -60,6 +60,16 @@ class TestDeployConfigModel:
         assert result["image"] == "test:latest"
         assert result["max_session_duration"] == 600
 
+    @pytest.mark.parametrize("value", [59, 14401, 0, -1])
+    def test_rejects_out_of_range(self, value):
+        with pytest.raises(ValueError, match="max_session_duration"):
+            DeployConfigParams(max_session_duration=value)
+
+    @pytest.mark.parametrize("value", [60, 7200, 14400])
+    def test_accepts_boundary_values(self, value):
+        config = DeployConfigParams(max_session_duration=value)
+        assert config.max_session_duration == value
+
 
 class TestTOMLConfiguration:
     """max_session_duration can be loaded from pcc-deploy.toml."""

--- a/tests/test_max_session_duration.py
+++ b/tests/test_max_session_duration.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for the --max-session-duration flag on `pcc deploy`.
+
+Covers the data model, TOML parsing, and API payload construction.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Import from source, not installed package
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from pipecatcloud._utils.deploy_utils import DeployConfigParams, load_deploy_config_file
+from pipecatcloud.api import _API
+
+
+class TestDeployConfigModel:
+    """DeployConfigParams stores and round-trips max_session_duration."""
+
+    def test_default_is_none(self):
+        # Arrange & Act
+        config = DeployConfigParams()
+
+        # Assert
+        assert config.max_session_duration is None
+
+    def test_can_be_set(self):
+        # Arrange & Act
+        config = DeployConfigParams(max_session_duration=3600)
+
+        # Assert
+        assert config.max_session_duration == 3600
+
+    def test_round_trips_through_to_dict(self):
+        # Arrange
+        config = DeployConfigParams(agent_name="test-agent", max_session_duration=3600)
+
+        # Act
+        result = config.to_dict()
+
+        # Assert
+        assert result["max_session_duration"] == 3600
+
+    def test_preserves_other_settings(self):
+        # Arrange
+        config = DeployConfigParams(
+            agent_name="test-agent",
+            image="test:latest",
+            max_session_duration=600,
+        )
+
+        # Act
+        result = config.to_dict()
+
+        # Assert
+        assert result["agent_name"] == "test-agent"
+        assert result["image"] == "test:latest"
+        assert result["max_session_duration"] == 600
+
+
+class TestTOMLConfiguration:
+    """max_session_duration can be loaded from pcc-deploy.toml."""
+
+    @pytest.fixture
+    def temp_config_file(self, tmp_path):
+        config_path = tmp_path / "pcc-deploy.toml"
+        return config_path
+
+    def test_loads_from_toml(self, temp_config_file):
+        # Arrange
+        config_content = """
+agent_name = "my-agent"
+image = "test:latest"
+max_session_duration = 300
+"""
+        temp_config_file.write_text(config_content)
+
+        # Act
+        with patch("pipecatcloud.cli.config.deploy_config_path", str(temp_config_file)):
+            config = load_deploy_config_file()
+
+        # Assert
+        assert config is not None
+        assert config.max_session_duration == 300
+
+    def test_absent_in_toml_is_none(self, temp_config_file):
+        # Arrange
+        config_content = """
+agent_name = "my-agent"
+image = "test:latest"
+"""
+        temp_config_file.write_text(config_content)
+
+        # Act
+        with patch("pipecatcloud.cli.config.deploy_config_path", str(temp_config_file)):
+            config = load_deploy_config_file()
+
+        # Assert
+        assert config is not None
+        assert config.max_session_duration is None
+
+
+class TestAPIPayload:
+    """API client sends maxSessionDuration in camelCase."""
+
+    @pytest.fixture
+    def api_client(self):
+        return _API(token="test-token", is_cli=True)
+
+    @pytest.mark.asyncio
+    async def test_payload_includes_max_session_duration(self, api_client):
+        # Arrange
+        config = DeployConfigParams(
+            agent_name="test-agent", image="test:latest", max_session_duration=600
+        )
+
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"success": True}
+
+            # Act
+            await api_client._deploy(config, "test-org", update=False)
+
+            # Assert
+            payload = mock_request.call_args[1]["json"]
+            assert payload["maxSessionDuration"] == 600
+
+    @pytest.mark.asyncio
+    async def test_payload_omits_field_when_unset(self, api_client):
+        """When max_session_duration is None, remove_none_values strips it."""
+        # Arrange
+        config = DeployConfigParams(agent_name="test-agent", image="test:latest")
+
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"success": True}
+
+            # Act
+            await api_client._deploy(config, "test-org", update=False)
+
+            # Assert
+            payload = mock_request.call_args[1]["json"]
+            assert "maxSessionDuration" not in payload


### PR DESCRIPTION
Remove the typer help doc max limitation of 50 agents since requests can be higher upon request.