### PR TITLE
fix: remove 50-agent cap on --max-agents and --max-instances

### DIFF
--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -514,10 +514,9 @@ def create_deploy_command(app: typer.Typer):
             None,
             "--max-agents",
             "-max",
-            help="Maximum number of allowed agents",
+            help="Maximum number of allowed agents (default cap 50, contact support to raise)",
             rich_help_panel="Deployment Configuration",
             min=1,
-            max=50,
         ),
         secret_set: str = typer.Option(
             None,
@@ -624,7 +623,6 @@ def create_deploy_command(app: typer.Typer):
             help="[Deprecated] Use --max-agents instead",
             hidden=True,
             min=1,
-            max=50,
         ),
     ):
         # Handle @deprecated options


### PR DESCRIPTION
The hard ceiling of 50 does not reflect the actual server-side limit, so blocking users at parse time produced spurious errors. Keep the lower bound and let the API enforce the real maximum.