### PR TITLE
Deprecate *SessionArguments in favor of pipecat-ai runner types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- The legacy session-argument classes in `pipecatcloud.agent`
+  (`SessionArguments`, `PipecatSessionArguments`, `DailySessionArguments`,
+  `WebSocketSessionArguments`, `SmallWebRTCSessionArguments`) are now
+  deprecated aliases of the corresponding `*RunnerArguments` from
+  [pipecat-ai](https://pypi.org/project/pipecat-ai/). The `session_id`
+  field, previously contributed by `SessionArguments`, now lives on
+  `pipecat.runner.types.RunnerArguments` directly.
+
+  Existing imports keep working unchanged. `isinstance` checks against
+  the legacy names continue to resolve because each alias is the same
+  class object as its target. New code should import the canonical names
+  from `pipecat.runner.types`.
+
 ## [0.6.0] - 2026-04-22
 
 ### Added

--- a/src/pipecatcloud/agent.py
+++ b/src/pipecatcloud/agent.py
@@ -4,13 +4,23 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+"""Session argument types for Pipecat Cloud bots.
+
+The canonical runner argument types live in :mod:`pipecat.runner.types`.
+The legacy ``*SessionArguments`` names defined here are deprecated aliases
+kept for backwards compatibility; new code should import the corresponding
+``*RunnerArguments`` from pipecat-ai directly.
+"""
+
 import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
 from fastapi import WebSocket
 
-# Try to import new types from pipecat-ai
+# The runner types are owned by pipecat-ai. Fall back to in-package
+# definitions when pipecat-ai is not installed so the CLI can still import
+# this module; the fallback is deprecated and will be removed.
 try:
     from pipecat.runner.types import (
         DailyRunnerArguments,
@@ -18,144 +28,64 @@ try:
         SmallWebRTCRunnerArguments,
         WebSocketRunnerArguments,
     )
-
-    _PIPECAT_RUNNER_TYPES_AVAILABLE = True
 except ImportError:
-    _PIPECAT_RUNNER_TYPES_AVAILABLE = False
 
-    # Fallback definitions
     @dataclass
     class RunnerArguments:
-        """Base class for runner session arguments.
+        """Fallback base class used when pipecat-ai is not installed.
 
         .. deprecated:: 0.2.2
-            Install pipecatcloud[pipecat] for better compatibility. This class
-            will be removed in a future release.
+            Install ``pipecatcloud[pipecat]`` for full compatibility. The
+            standalone fallback will be removed in a future release.
         """
 
         handle_sigint: bool = field(init=False, kw_only=True)
         handle_sigterm: bool = field(init=False, kw_only=True)
         pipeline_idle_timeout_secs: int = field(init=False, kw_only=True)
         body: Any | None = field(default_factory=dict, kw_only=True)
+        session_id: str | None = field(default=None, kw_only=True)
 
         def __post_init__(self):
             self.handle_sigint = False
             self.handle_sigterm = False
             self.pipeline_idle_timeout_secs = 300
+            warnings.warn(
+                "Using standalone pipecatcloud session arguments without "
+                "pipecat-ai. For full compatibility, install: "
+                "pip install pipecatcloud[pipecat]. Standalone mode will be "
+                "removed in a future release.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
     @dataclass
     class DailyRunnerArguments(RunnerArguments):
-        """Fallback Daily runner arguments when pipecat-ai not available.
-
-        .. deprecated:: 0.2.1
-            Install pipecatcloud[pipecat] for better compatibility.
-        """
+        """Fallback Daily runner arguments when pipecat-ai is not available."""
 
         room_url: str
         token: str
 
     @dataclass
     class WebSocketRunnerArguments(RunnerArguments):
-        """Fallback WebSocket runner arguments when pipecat-ai not available.
-
-        .. deprecated:: 0.2.1
-            Install pipecatcloud[pipecat] for better compatibility.
-        """
+        """Fallback WebSocket runner arguments when pipecat-ai is not available."""
 
         websocket: WebSocket
 
     @dataclass
     class SmallWebRTCRunnerArguments(RunnerArguments):
-        """Fallback Small WebRTC transport session arguments for the runner.
-
-        Parameters:
-            webrtc_connection: Pre-configured WebRTC peer connection
-        """
+        """Fallback SmallWebRTC runner arguments when pipecat-ai is not available."""
 
         webrtc_connection: Any
 
 
-def _warn_standalone_usage():
-    """Warn users about standalone session arguments usage."""
-    if not _PIPECAT_RUNNER_TYPES_AVAILABLE:
-        warnings.warn(
-            "Using standalone pipecatcloud session arguments without pipecat-ai. "
-            "For better compatibility, install: pip install pipecatcloud[pipecat]. "
-            "Standalone mode will be removed in a future release.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-
-
-@dataclass
-class SessionArguments:
-    """Base class for common agent session arguments.
-
-    The arguments are received by the bot() entry point.
-
-    Parameters:
-        session_id (str | None): The unique identifier for the session.
-            This is used to track the session across requests.
-    """
-
-    session_id: str | None
-
-
-@dataclass
-class PipecatSessionArguments(RunnerArguments, SessionArguments):
-    """Standard Pipecat Cloud agent session arguments.
-
-    Inherits from RunnerArguments for compatibility with pipecat-ai runner.
-    When pipecat-ai is not installed, uses a fallback implementation (deprecated).
-
-    For best compatibility, install: pip install pipecatcloud[pipecat]
-    """
-
-    def __post_init__(self):
-        RunnerArguments.__post_init__(self)
-        _warn_standalone_usage()
-
-
-@dataclass
-class DailySessionArguments(DailyRunnerArguments, SessionArguments):
-    """Daily based agent session arguments.
-
-    Inherits from DailyRunnerArguments for compatibility with pipecat-ai runner.
-    When pipecat-ai is not installed, uses a fallback implementation (deprecated).
-
-    For best compatibility, install: pip install pipecatcloud[pipecat]
-    """
-
-    def __post_init__(self):
-        DailyRunnerArguments.__post_init__(self)
-        _warn_standalone_usage()
-
-
-@dataclass
-class WebSocketSessionArguments(WebSocketRunnerArguments, SessionArguments):
-    """WebSocket based agent session arguments.
-
-    Inherits from WebSocketRunnerArguments for compatibility with pipecat-ai runner.
-    When pipecat-ai is not installed, uses a fallback implementation (deprecated).
-
-    For best compatibility, install: pip install pipecatcloud[pipecat]
-    """
-
-    def __post_init__(self):
-        WebSocketRunnerArguments.__post_init__(self)
-        _warn_standalone_usage()
-
-
-@dataclass
-class SmallWebRTCSessionArguments(SmallWebRTCRunnerArguments, SessionArguments):
-    """SmallWebRTCTransport based agent session arguments.
-
-    Inherits from SmallWebRTCRunnerArguments for compatibility with pipecat-ai runner.
-    When pipecat-ai is not installed, uses a fallback implementation (deprecated).
-
-    For best compatibility, install: pip install pipecatcloud[pipecat]
-    """
-
-    def __post_init__(self):
-        SmallWebRTCRunnerArguments.__post_init__(self)
-        _warn_standalone_usage()
+# Deprecated session-argument aliases. The runner types now carry the
+# ``session_id`` field directly, so the legacy ``*SessionArguments`` classes
+# collapse to straight aliases. Existing imports keep working unchanged
+# (``isinstance`` and type annotations both resolve identically because each
+# alias is the same class object as its target). New code should import the
+# canonical names from :mod:`pipecat.runner.types`.
+SessionArguments = RunnerArguments
+PipecatSessionArguments = RunnerArguments
+DailySessionArguments = DailyRunnerArguments
+WebSocketSessionArguments = WebSocketRunnerArguments
+SmallWebRTCSessionArguments = SmallWebRTCRunnerArguments


### PR DESCRIPTION
Requires pipecat-ai 1.2.0 release first, which will include this change:
https://github.com/pipecat-ai/pipecat/pull/4385

## Summary

Collapse the `*SessionArguments` hierarchy to straight aliases of the corresponding `*RunnerArguments` from pipecat-ai. The `session_id` field that `SessionArguments` used to contribute via multiple inheritance now lives on `pipecat.runner.types.RunnerArguments` upstream, so the cloud-side wrappers no longer add anything.

This is the second step in unifying bot argument types under pipecat-ai. The companion change to add `session_id` to `RunnerArguments` is on the pipecat-ai branch `mb/runner-session-id`.

## Backwards compatibility

- `from pipecatcloud import DailySessionArguments` still resolves.
- Type annotations like `async def bot(args: DailySessionArguments):` still match, because the alias is literally the upstream class.
- `isinstance(args, DailySessionArguments)` still returns `True` for the same reason.

Verified manually in both modes:

- **With pipecat-ai installed:** aliases are the upstream classes; `DailySessionArguments(session_id=..., room_url=..., token=..., body=...)` constructs cleanly and `args.session_id` carries through.
- **Without pipecat-ai:** aliases collapse to the local fallback dataclasses (which now include `session_id`), and the standalone-mode `DeprecationWarning` still fires on construction.

## Release TODO

Before tagging this release, bump the constraint in `pyproject.toml`:

```toml
[project.optional-dependencies]
pipecat = ["pipecat-ai>=X.Y.Z"]
```

to the pipecat-ai version that contains the `session_id` field on `RunnerArguments`. Without that bump, callers can install pipecatcloud alongside an older pipecat-ai where `DailySessionArguments(session_id=...)` would fail with `TypeError`.

## Follow-up

Once base image releases include the new pipecatcloud, the alias surface can be removed entirely in a later major release. Tracked separately as part of the broader runner-type unification.

## Test plan

- [ ] `uv run pytest`
- [ ] `uv run ruff check . && uv run ruff format --check .`
- [ ] Manual: `from pipecatcloud import DailySessionArguments; DailySessionArguments(session_id="x", room_url="y", token="z")` works and `args.session_id == "x"`.
- [ ] Manual: deploy a bot signed `async def bot(args: DailySessionArguments):` and confirm `args.session_id` matches the `x-daily-session-id` header.