### PR TITLE
feat: render API-supplied health headlines in agent status (PCC-822)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `pcc agent status` and the `pcc deploy` polling output now show
+  customer-friendly headlines for failed deployments when the API
+  supplies them. An OOM-killed container reads "Out of memory" instead
+  of "CrashLoopBackOff (OOMKilled, exit 137)"; an application crash
+  reads "Application Error" with the captured traceback on the next
+  line. Exit codes render as "exit code N" rather than "exit N" for
+  clarity. Older API responses without the new field continue to render
+  via the previous format.
+
 ## [0.6.0] - 2026-04-22
 
 ### Added

--- a/src/pipecatcloud/_utils/deploy_utils.py
+++ b/src/pipecatcloud/_utils/deploy_utils.py
@@ -104,25 +104,37 @@ def format_health_lines(health: dict) -> list:
     """Format health details as indented lines under a revision."""
     lines = []
     reason_parts = []
+
+    # Prefer the customer-friendly headline from the API when present. Older API
+    # responses don't include it, so fall back to constructing a string from raw
+    # k8s fields.
+    headline = health.get("headline")
     reason = health.get("reason", "")
     term_reason = health.get("lastTerminationReason", "")
     exit_code = health.get("lastExitCode")
 
-    if reason:
+    if headline:
+        reason_parts.append(f"[red]{headline}[/red]")
+    elif reason:
         detail = reason
         if term_reason and term_reason != reason:
             detail += f" ({term_reason}"
             if exit_code is not None:
-                detail += f", exit {exit_code}"
+                detail += f", exit code {exit_code}"
             detail += ")"
         elif exit_code is not None:
-            detail += f" (exit {exit_code})"
+            detail += f" (exit code {exit_code})"
         reason_parts.append(f"[red]{detail}[/red]")
 
     restarts = health.get("restartCount", 0)
     replicas_started = health.get("replicasStarted", 0)
     if restarts > 0:
         reason_parts.append(f"[dim]·[/dim] {restarts} restarts across {replicas_started} replicas")
+
+    # When using the headline, surface the exit code as its own subhead segment.
+    # The fallback path already includes the exit code inline with the reason.
+    if headline and exit_code is not None:
+        reason_parts.append(f"[dim]·[/dim] exit code {exit_code}")
 
     if reason_parts:
         lines.append("      " + " ".join(reason_parts))

--- a/tests/test_deployment_status.py
+++ b/tests/test_deployment_status.py
@@ -497,7 +497,7 @@ class TestHealthLines:
         assert len(lines) >= 1
         assert "CrashLoopBackOff" in lines[0]
         assert "OOMKilled" in lines[0]
-        assert "exit 137" in lines[0]
+        assert "exit code 137" in lines[0]
         assert "42 restarts" in lines[0]
         assert "3 replicas" in lines[0]
 
@@ -511,7 +511,7 @@ class TestHealthLines:
             }
         )
         assert "Error" in lines[0]
-        assert "exit 1" in lines[0]
+        assert "exit code 1" in lines[0]
         assert "4 restarts" in lines[0]
 
     def test_message_shows_last_line(self):
@@ -564,8 +564,86 @@ class TestHealthLines:
                 "replicasStarted": 1,
             }
         )
-        # Should show "Error (exit 1)" not "Error (Error, exit 1)"
-        assert "Error (exit 1)" in lines[0]
+        # Should show "Error (exit code 1)" not "Error (Error, exit code 1)"
+        assert "Error (exit code 1)" in lines[0]
+
+    def test_headline_replaces_reason_string(self):
+        """When the API supplies a customer-friendly headline, render it instead of
+        the raw k8s reason. Exit code is appended as its own segment so it stays
+        visible (today's format folded the exit code into the reason string)."""
+        lines = format_health_lines(
+            {
+                "reason": "CrashLoopBackOff",
+                "lastTerminationReason": "OOMKilled",
+                "lastExitCode": 137,
+                "restartCount": 5,
+                "replicasStarted": 2,
+                "headline": "Out of memory",
+            }
+        )
+        assert "Out of memory" in lines[0]
+        # Raw k8s vocabulary should NOT appear in the rendered line when we have a headline.
+        assert "CrashLoopBackOff" not in lines[0]
+        assert "OOMKilled" not in lines[0]
+        # Restart count and exit code are both visible.
+        assert "5 restarts across 2 replicas" in lines[0]
+        assert "exit code 137" in lines[0]
+
+    def test_headline_with_traceback_message(self):
+        """Application Error case: headline plus the last line of the captured traceback."""
+        lines = format_health_lines(
+            {
+                "reason": "CrashLoopBackOff",
+                "lastTerminationReason": "Error",
+                "lastExitCode": 1,
+                "restartCount": 3,
+                "replicasStarted": 2,
+                "headline": "Application Error",
+                "message": (
+                    "Traceback (most recent call last):\n"
+                    '  File "bot.py"\n'
+                    "ModuleNotFoundError: No module named 'nonexistentlibthiswillfail'"
+                ),
+            }
+        )
+        assert len(lines) == 2
+        assert "Application Error" in lines[0]
+        assert "exit code 1" in lines[0]
+        assert "ModuleNotFoundError" in lines[1]
+        assert "Traceback" not in lines[1]
+
+    def test_headline_without_exit_code(self):
+        """ImagePullBackOff and similar pre-start failures have no exit code; the
+        exit-code segment must be omitted, not rendered as 'exit None' or similar."""
+        lines = format_health_lines(
+            {
+                "reason": "ImagePullBackOff",
+                "restartCount": 0,
+                "replicasStarted": 2,
+                "headline": "Cannot pull image",
+                "message": 'Back-off pulling image "nonexistent:latest"',
+            }
+        )
+        assert "Cannot pull image" in lines[0]
+        assert "exit" not in lines[0]
+        assert "ImagePullBackOff" not in lines[0]
+        assert "nonexistent:latest" in lines[1]
+
+    def test_unmapped_reason_falls_back_to_raw_format(self):
+        """An older API response (or a future unmapped reason) has no headline;
+        rendering must continue to work via the fallback path."""
+        lines = format_health_lines(
+            {
+                "reason": "CrashLoopBackOff",
+                "lastTerminationReason": "OOMKilled",
+                "lastExitCode": 137,
+                "restartCount": 5,
+                "replicasStarted": 2,
+            }
+        )
+        # Existing format preserved exactly: parens, comma, k8s vocabulary.
+        assert "CrashLoopBackOff (OOMKilled, exit code 137)" in lines[0]
+        assert "5 restarts across 2 replicas" in lines[0]
 
 
 class TestRevisionLineWithHealth:


### PR DESCRIPTION
format_health_lines now prefers health.headline when the API provides one, showing the customer-friendly label (e.g. "Out of memory") instead of the raw k8s vocabulary ("CrashLoopBackOff (OOMKilled, exit 137)"). The exit code is appended as its own subhead segment so it remains visible.

Older API responses without the headline field continue to render via the existing string-construction path — additive on the API side, so no release-order constraint between API and CLI.