### PR TITLE
feat(secrets): show readiness status in `pcc secrets list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `pcc secrets list` now shows a `Status` column for each secret set
+  (`ready`, `pending`, or `failed`). When a single set is requested
+  (`pcc secrets list <name>`), the readiness status is shown in the panel
+  title alongside the keys, and a follow-up message explains pending or
+  failed states. Backed by a new `secrets_get` API client method that
+  fetches a single secret set's full payload, including readiness fields.
+
 ## [0.6.0] - 2026-04-22
 
 ### Added

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -354,6 +354,27 @@ class _API:
         """
         return self.create_api_method(self._secrets_list)
 
+    async def _secrets_get(self, org: str, secret_set: str) -> dict | None:
+        """Fetch a single secret set, including its readiness status.
+
+        Returns the full response object: {secrets, region, status, errorMessage?}.
+        Use this when you need readiness; use _secrets_list when you only need
+        the existence check or the flat keys array.
+        """
+        url = f"{self.construct_api_url('secrets_path').format(org=org)}/{secret_set}"
+        result = await self._base_request("GET", url, not_found_is_empty=True)
+        return result or None
+
+    @property
+    def secrets_get(self):
+        """Get a single secret set with readiness status.
+
+        Args:
+            org: Organization ID
+            secret_set: Name of the secret set
+        """
+        return self.create_api_method(self._secrets_get)
+
     async def _secrets_upsert(
         self, data: dict, set_name: str, org: str, region: str | None = None
     ) -> dict:

--- a/src/pipecatcloud/cli/commands/secrets.py
+++ b/src/pipecatcloud/cli/commands/secrets.py
@@ -33,6 +33,17 @@ secrets_cli = typer.Typer(
 # ---- Methods ----
 
 
+def _format_status(status: str | None) -> str:
+    """Render a readiness status with Rich styling. Unknown values pass through."""
+    if status == "ready":
+        return "[green]ready[/green]"
+    if status == "pending":
+        return "[yellow]pending[/yellow]"
+    if status == "failed":
+        return "[red]failed[/red]"
+    return status or "[dim]unknown[/dim]"
+
+
 def validate_secrets(secrets: dict):
     valid_name_pattern = re.compile(r"^[a-zA-Z0-9_-]+$")
 
@@ -382,7 +393,10 @@ async def list(
     logger.debug(f"Secret set name to lookup: {name}")
 
     with console.status(f"[dim]{status_title}[/dim]", spinner="dots"):
-        data, error = await API.bubble_error().secrets_list(org=org, secret_set=name, region=region)
+        if name:
+            data, error = await API.bubble_error().secrets_get(org=org, secret_set=name)
+        else:
+            data, error = await API.bubble_error().secrets_list(org=org, region=region)
 
         if error:
             if error == 400:
@@ -401,19 +415,27 @@ async def list(
             return typer.Exit()
 
         if name:
-            # Match
+            secrets = data.get("secrets") or []
+            status = data.get("status")
+            error_message = data.get("errorMessage")
 
             table = Table(border_style="dim", show_header=False, show_edge=True, show_lines=True)
             table.add_column(name, style="white")
-            for s in data:
+            for s in secrets:
                 table.add_row(s["fieldName"])
-            console.print(
-                Panel(
-                    table,
-                    title=f"[bold]Secret keys for set [green]{name}[/green][/bold]",
-                    title_align="left",
-                )
+
+            title = (
+                f"[bold]Secret keys for set [green]{name}[/green][/bold] "
+                f"(status: {_format_status(status)})"
             )
+            console.print(Panel(table, title=title, title_align="left"))
+            if status == "failed" and error_message:
+                console.print(f"[red]{error_message}[/red]")
+            elif status == "pending":
+                console.print(
+                    "[yellow]This secret set is still being provisioned. "
+                    "Deploys that bind it will be rejected until it is ready.[/yellow]"
+                )
         else:
             # Filter out image pull secrets if show all is False
             filtered_sets = [s for s in data if show_all or s["type"] != "imagePullSecret"]
@@ -431,6 +453,7 @@ async def list(
             )
             table.add_column("Secret Set Name", style="white")
             table.add_column("Region", style="white")
+            table.add_column("Status", style="white")
             if show_all:
                 table.add_column("Type", style="white")
                 for secret_set in filtered_sets:
@@ -439,10 +462,19 @@ async def list(
                         if secret_set["type"] == "imagePullSecret"
                         else "Secret Set"
                     )
-                    table.add_row(secret_set["name"], secret_set["region"], set_type)
+                    table.add_row(
+                        secret_set["name"],
+                        secret_set["region"],
+                        _format_status(secret_set.get("status")),
+                        set_type,
+                    )
             else:
                 for secret_set in filtered_sets:
-                    table.add_row(secret_set["name"], secret_set["region"])
+                    table.add_row(
+                        secret_set["name"],
+                        secret_set["region"],
+                        _format_status(secret_set.get("status")),
+                    )
 
             console.success(table, title_extra=f"Secret sets for {org}")
 

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -72,6 +72,41 @@ class TestAPISecretsRegions:
             assert call_args[1]["params"] == {"region": "ap"}
 
     @pytest.mark.asyncio
+    async def test_secrets_get_returns_full_response(self, api_client):
+        """secrets_get returns the whole single-set response, including readiness fields."""
+        # Arrange
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {
+                "secrets": [{"fieldName": "API_KEY"}],
+                "region": "us-west",
+                "status": "ready",
+            }
+
+            # Act
+            result = await api_client._secrets_get(org="test-org", secret_set="my-secrets")
+
+            # Assert
+            mock_request.assert_called_once()
+            assert result == {
+                "secrets": [{"fieldName": "API_KEY"}],
+                "region": "us-west",
+                "status": "ready",
+            }
+
+    @pytest.mark.asyncio
+    async def test_secrets_get_returns_none_on_404(self, api_client):
+        """secrets_get returns None when the set does not exist."""
+        # Arrange
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = None
+
+            # Act
+            result = await api_client._secrets_get(org="test-org", secret_set="missing")
+
+            # Assert
+            assert result is None
+
+    @pytest.mark.asyncio
     async def test_secrets_upsert_with_region(self, api_client):
         """Secrets upsert with region should include region in payload."""
         # Arrange


### PR DESCRIPTION
The API now returns a per-set readiness status (`ready` / `pending` / `failed`) on GET /secrets and GET /secrets/{name}, gating deploys on the `ready` state. Surface it in the CLI:

- `pcc secrets list` adds a Status column.
- `pcc secrets list <name>` shows the status next to the panel title and prints a follow-up note for pending/failed sets.
- New `secrets_get` API client method returns the full single-set response (including readiness fields). Existing `secrets_list` callers (deploy verification, set existence check) are unchanged.

Tests cover both the new method's success path and its 404 handling.