### PR TITLE
Python 3.14 compatibility for the pcc CLI

### DIFF
--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -1,0 +1,45 @@
+name: python-compatibility
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  group: python-compat-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compat:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12', '3.13', '3.14']
+
+    name: Python ${{ matrix.python-version }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: 'latest'
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: |
+          uv python install ${{ matrix.python-version }}
+          uv python pin ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Verify CLI loads
+        run: |
+          uv run python --version
+          uv run pcc --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.1] - 2026-05-14
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The `pcc` CLI now imports cleanly under Python 3.14. Previously, two
+  Typer command callbacks were defined with the names `list` and `set`,
+  shadowing the builtins. Under PEP 649's lazy annotation evaluation in
+  3.14, a separate command annotated `secrets: list[str]` then resolved
+  `list` to the decorated `FunctionWithAio` object and failed with
+  `TypeError: 'FunctionWithAio' object is not subscriptable` at import
+  time, breaking every CLI entrypoint. The callbacks have been renamed
+  (`create_set`, `list_sets`, `list_agents`, `list_organizations`); the
+  user-facing command names (`pcc secrets set`, `pcc secrets list`,
+  `pcc agent list`, `pcc organizations list`) are unchanged.
+
 ## [0.7.0] - 2026-05-07
 
 ### Added

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -89,7 +89,7 @@ def format_cpu(millicores: int) -> str:
 @agent_cli.command(name="list", help="List agents in an organization.")
 @synchronizer.create_blocking
 @requires_login
-async def list(
+async def list_agents(
     organization: str = typer.Option(
         None, "--organization", "-o", help="Organization to list agents for"
     ),

--- a/src/pipecatcloud/cli/commands/organizations.py
+++ b/src/pipecatcloud/cli/commands/organizations.py
@@ -96,7 +96,7 @@ async def select(organization: str = typer.Option(None, "--organization", "-o"))
 @organization_cli.command(name="list", help="List organizations user is a member of.")
 @synchronizer.create_blocking
 @requires_login
-async def list():
+async def list_organizations():
     current_org = config.get("org")
 
     with console.status(

--- a/src/pipecatcloud/cli/commands/secrets.py
+++ b/src/pipecatcloud/cli/commands/secrets.py
@@ -76,7 +76,7 @@ def validate_secret_name(name: str):
 @secrets_cli.command(name="set", help="Create a new secret set for active organization")
 @synchronizer.create_blocking
 @requires_login
-async def set(
+async def create_set(
     name: str = typer.Argument(help="Name of the secret set to create e.g. 'my-secret-set'"),
     secrets: list[str] = typer.Argument(
         None,
@@ -361,7 +361,7 @@ async def unset(
 @secrets_cli.command(name="list", help="List secret sets and set keys")
 @synchronizer.create_blocking
 @requires_login
-async def list(
+async def list_sets(
     name: str = typer.Argument(
         None, help="Name of the secret set to list secrets from e.g. 'my-secret-set'"
     ),

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -179,7 +179,7 @@ class TestCLIRegionValidation:
         """Secrets set should accept valid regions from API."""
         # Arrange
         from pipecatcloud._utils import regions
-        from pipecatcloud.cli.commands.secrets import set as secrets_set
+        from pipecatcloud.cli.commands.secrets import create_set as secrets_set
 
         regions._regions_cache = None
 


### PR DESCRIPTION
## Summary

- Rename four Typer command callbacks that shadowed builtins (`list`, `set`). Under Python 3.14 (PEP 649), annotations are evaluated lazily against module globals, so a later `async def list` overwrote the name before Typer inspected an earlier `secrets: list[str]` annotation — raising `TypeError: 'FunctionWithAio' object is not subscriptable` at CLI import time. User-facing command names are unchanged since each `@*_cli.command(name=...)` is explicit.
- Add a `python-compatibility` workflow that matrixes 3.11–3.14, runs `uv sync --group dev`, then `uv run pcc --help`. The help command walks the full Typer command tree, which is exactly the path that surfaced this regression — `import pipecatcloud` alone would not have.

## Test plan

- [ ] CI: new `python-compatibility` job passes on all four Python versions
- [ ] CI: existing `tests` and `format` jobs still pass
- [ ] Local: `uv run pcc --help` succeeds (verified on 3.13)
- [ ] Local: `uv run --python 3.14 pcc --help` succeeds (verified by reporter)
- [ ] Local: `uv run pytest tests/test_regions.py` passes (the rename touched one import alias here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)