### PR TITLE
fix(deploy): handle transient poll failures without crashing (PCC-872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.2] - 2026-05-29
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `pcc deploy` no longer crashes with `AttributeError: 'NoneType' object has
+  no attribute 'get'` when a status poll hits a transient API error (e.g. a
+  502 from a briefly-unavailable API pod). The poll loop now checks for the
+  error before reading the status payload, and transient failures (5xx,
+  network blips, a not-yet-visible service) are retried for up to 5
+  consecutive attempts before giving up. A successful poll resets that
+  budget, so an isolated blip no longer surfaces as a traceback or fails an
+  otherwise-successful deploy. Non-transient errors (4xx, auth) still abort
+  immediately.
+
 ## [0.7.1] - 2026-05-14
 
 ### Fixed

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -43,6 +43,31 @@ from pipecatcloud.constants import KRISP_VIVA_MODELS, Region
 
 MAX_ALIVE_CHECKS = 120
 ALIVE_CHECK_SLEEP = 5
+# How many *consecutive* transient status-poll failures to tolerate before
+# giving up. A single successful poll resets this budget, so this only trips on
+# a sustained outage, not on isolated blips.
+MAX_CONSECUTIVE_POLL_FAILURES = 5
+
+
+def _poll_failure_is_transient(error: dict | None) -> bool:
+    """Decide whether a failed status poll should be retried rather than aborting.
+
+    A status poll can fail in a few ways, and only some are worth retrying:
+
+    - **No error payload** (``error is None``): the request never received a
+      response (connection reset, timeout) or the service object isn't visible
+      yet. Always transient.
+    - **5xx**: a server-side blip (e.g. the 502 from PCC-867). Transient.
+    - **4xx or a non-numeric application code**: a real client/auth/config
+      problem that won't clear on its own. Not transient — abort.
+    """
+    if not error:
+        return True
+    code = str(error.get("code", "")) if isinstance(error, dict) else ""
+    if code.isdigit():
+        return 500 <= int(code) <= 599
+    return False
+
 
 # ----- Cloud Build Flow
 
@@ -356,6 +381,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
     is_ready = False
     last_status = None
     checks_performed = 0
+    consecutive_failures = 0
 
     console.print(
         f"[bold cyan]{'Updating' if existing_agent else 'Pushing'}[/bold cyan] deployment for agent '{params.agent_name}'"
@@ -375,6 +401,46 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
 
                 logger.debug(f"Deployment status: {agent_status}")
 
+                # A failed poll returns (None, error). Handle that here, *before*
+                # touching agent_status, so a transient blip can't crash the
+                # deploy with an AttributeError on None. Transient failures (5xx,
+                # network, not-yet-visible service) are retried up to a small
+                # consecutive cap; non-transient ones (4xx/auth) abort right away.
+                if error or agent_status is None:
+                    if _poll_failure_is_transient(error):
+                        consecutive_failures += 1
+                        if consecutive_failures <= MAX_CONSECUTIVE_POLL_FAILURES:
+                            logger.debug(
+                                "Transient status-poll failure "
+                                f"({consecutive_failures}/{MAX_CONSECUTIVE_POLL_FAILURES}): "
+                                f"{error}"
+                            )
+                            status.update(
+                                "[dim]Waiting for deployment status "
+                                "(retrying after a transient API error)...[/dim]"
+                            )
+                            await asyncio.sleep(ALIVE_CHECK_SLEEP)
+                            checks_performed += 1
+                            continue
+                        # Sustained failures — the deploy itself may well have
+                        # succeeded, so point the user at `agent status` rather
+                        # than implying it failed.
+                        status.stop()
+                        console.error(
+                            "Error checking deployment status: the API returned a "
+                            f"transient error {MAX_CONSECUTIVE_POLL_FAILURES} times in a row.\n"
+                            "Your deployment may still be in progress. Check it with "
+                            f"`{PIPECAT_CLI_NAME} agent status {params.agent_name}`"
+                        )
+                        return typer.Exit()
+                    # Non-transient error (4xx, auth, etc.) — abort immediately.
+                    status.stop()
+                    console.error("Error checking deployment status")
+                    return typer.Exit()
+
+                # Successful poll — reset the transient-failure budget.
+                consecutive_failures = 0
+
                 # Look for any error messages in the agent status
                 # Exit out of the polling loop if we find an error
                 status_errors = agent_status.get("errors", [])
@@ -386,11 +452,6 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
                         console.api_error(error_message, "Agent deployment failed")
                     else:
                         console.error(f"Deployment failed with an unknown error: {status_errors}")
-                    return typer.Exit()
-
-                if error:
-                    status.stop()
-                    console.error("Error checking deployment status")
                     return typer.Exit()
 
                 # Capture the deployment ID for display

--- a/tests/test_deploy_poll.py
+++ b/tests/test_deploy_poll.py
@@ -1,0 +1,43 @@
+"""
+Unit tests for deploy status-poll failure handling (PCC-872).
+
+The deploy poll loop must not crash when a status poll fails: `API.agent`
+returns `(None, error)` on any non-2xx, so the loop has to classify the failure
+before touching the (None) status payload. `_poll_failure_is_transient` is that
+classifier — transient blips get retried, real problems abort.
+"""
+
+from pipecatcloud.cli.commands.deploy import _poll_failure_is_transient
+
+
+class TestTransientFailures:
+    """Failures that should be retried rather than failing the deploy."""
+
+    def test_no_error_payload_is_transient(self):
+        # Network-level failures (timeout, connection reset) and 200-without-body
+        # responses surface as (None, None) — no structured error at all.
+        assert _poll_failure_is_transient(None) is True
+
+    def test_502_bad_gateway_is_transient(self):
+        # The exact case from the ticket: API pod cycled by its liveness probe.
+        assert _poll_failure_is_transient({"error": "Bad Gateway", "code": "502"}) is True
+
+    def test_500_and_503_are_transient(self):
+        assert _poll_failure_is_transient({"code": "500"}) is True
+        assert _poll_failure_is_transient({"code": "503"}) is True
+
+
+class TestFatalFailures:
+    """Failures that won't clear on their own and should abort the deploy."""
+
+    def test_4xx_is_fatal(self):
+        assert _poll_failure_is_transient({"error": "Unauthorized", "code": "401"}) is False
+        assert _poll_failure_is_transient({"error": "Not Found", "code": "404"}) is False
+
+    def test_non_numeric_application_code_is_fatal(self):
+        # Structured PCC errors carry codes like this rather than HTTP statuses.
+        assert _poll_failure_is_transient({"code": "AGENT_CONFIG_INVALID"}) is False
+
+    def test_missing_code_with_error_present_is_fatal(self):
+        # An error dict with no code we can classify: don't assume retryable.
+        assert _poll_failure_is_transient({"error": "something broke"}) is False


### PR DESCRIPTION
The status-poll loop called agent_status.get("errors", []) before the if-error guard. Since API.agent returns (None, error) on any non-2xx, a transient 502 mid-deploy raised AttributeError: 'NoneType' object has no attribute 'get' instead of degrading gracefully.

Check for the failure before reading the status payload, and retry transient failures (5xx, network blips, a not-yet-visible service) up to 5 consecutive attempts; a successful poll resets the budget. Non-transient errors (4xx, auth) still abort immediately.