### PR TITLE
PCC-807: spend-limit show|set|clear CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- New `pcc spend-limit` command group for managing the organization-level
+  spend cap added in PCC-801:
+  - `pcc spend-limit show` prints the current limit, period spend, period
+    boundaries, and blocked state. Pass `--json` for machine-readable output.
+  - `pcc spend-limit set <amount>` sets a new limit. The amount is in
+    dollars with at most two decimal places (e.g. `50` or `12.34`). The
+    command prompts before setting the limit to `$0` or below current
+    spend; pass `-y/--yes` to skip the prompt.
+  - `pcc spend-limit clear` removes the limit, with the same confirmation
+    behavior.
+- Any CLI command that surfaces an HTTP 402 `SPEND_LIMIT_REACHED` error now
+  renders a wrapped remediation message that explains how to unblock new
+  sessions, instead of a generic API error panel.
+
 ## [0.7.2] - 2026-05-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New `pcc spend-limit` command group for managing the organization-level
-  spend cap added in PCC-801:
+  spend cap (PCC-807):
   - `pcc spend-limit show` prints the current limit, period spend, period
     boundaries, and blocked state. Pass `--json` for machine-readable output.
   - `pcc spend-limit set <amount>` sets a new limit. The amount is in

--- a/src/pipecatcloud/_utils/console_utils.py
+++ b/src/pipecatcloud/_utils/console_utils.py
@@ -14,10 +14,17 @@ from pipecatcloud.cli import PANEL_TITLE_ERROR, PANEL_TITLE_SUCCESS, PIPECAT_CLI
 
 
 def format_cents(cents: int | None) -> str:
-    """Render a cents value as a USD dollar string (e.g. 1234 -> "$12.34")."""
+    """Render a cents value as a USD dollar string (e.g. 1234 -> "$12.34").
+
+    Uses integer arithmetic so the rendered value is exact for any in-range
+    integer, even values float-division would round (e.g. very large cent
+    counts where `cents / 100` loses precision).
+    """
     if cents is None:
         return "no limit"
-    return f"${cents / 100:.2f}"
+    sign = "-" if cents < 0 else ""
+    abs_cents = abs(cents)
+    return f"{sign}${abs_cents // 100}.{abs_cents % 100:02d}"
 
 
 class PipecatConsole(Console):

--- a/src/pipecatcloud/_utils/console_utils.py
+++ b/src/pipecatcloud/_utils/console_utils.py
@@ -13,6 +13,13 @@ from rich.panel import Panel
 from pipecatcloud.cli import PANEL_TITLE_ERROR, PANEL_TITLE_SUCCESS, PIPECAT_CLI_NAME
 
 
+def format_cents(cents: int | None) -> str:
+    """Render a cents value as a USD dollar string (e.g. 1234 -> "$12.34")."""
+    if cents is None:
+        return "no limit"
+    return f"${cents / 100:.2f}"
+
+
 class PipecatConsole(Console):
     def success(
         self,
@@ -90,6 +97,11 @@ class PipecatConsole(Console):
             error_message = str(error_code) if error_code else DEFAULT_ERROR_MESSAGE
             code = None
 
+        if code == "SPEND_LIMIT_REACHED":
+            # Safe to pass through: code is only set when error_code is a dict.
+            self._spend_limit_reached(error_code)  # type: ignore[arg-type]
+            return
+
         if not error_message:
             hide_subtitle = True
 
@@ -102,6 +114,48 @@ class PipecatConsole(Console):
                 else None,
                 title_align="left",
                 subtitle_align="left",
+                border_style="red",
+            )
+        )
+
+    def _spend_limit_reached(self, error: dict):
+        """Render the wrapped remediation message for HTTP 402 SPEND_LIMIT_REACHED.
+
+        Falls back gracefully if the error body omits the spend fields: in that
+        case we render the remediation message without the usage line.
+        """
+        from pipecatcloud.config import config as base_config
+
+        current = error.get("currentSpendCents")
+        limit = error.get("limitCents")
+
+        if current is not None and limit is not None:
+            usage_line = (
+                f"Your organization has reached its spend limit "
+                f"({format_cents(current)} of {format_cents(limit)} used in this billing period)."
+            )
+        else:
+            usage_line = (
+                "Your organization has reached its spend limit for the current billing period."
+            )
+
+        # Fall back to the documented default if the host is unset or empty,
+        # so the rendered link is never `[link=][/link]` or `[link=None]None[/link]`.
+        dashboard = base_config.get("dashboard_host") or "https://pipecat.daily.co"
+        body = (
+            f"{usage_line}\n"
+            "New sessions are being rejected. In-flight sessions continue to run.\n\n"
+            "To unblock new sessions:\n"
+            f"  [bold cyan]{PIPECAT_CLI_NAME} spend-limit set <new amount>[/bold cyan]\n"
+            f"  [bold cyan]{PIPECAT_CLI_NAME} spend-limit clear[/bold cyan]\n\n"
+            f"Or visit [link={dashboard}]{dashboard}[/link]"
+        )
+
+        self.print(
+            Panel(
+                body,
+                title=f"[bold red]{PANEL_TITLE_ERROR} - Spend limit reached (402)[/bold red]",
+                title_align="left",
                 border_style="red",
             )
         )

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -695,6 +695,40 @@ class _API:
         """
         return self.create_api_method(self._properties_update)
 
+    # Spend Limit
+
+    async def _spend_limit_get(self, org: str) -> dict | None:
+        url = self.construct_api_url("spend_limit_path").format(org=org)
+        return await self._base_request("GET", url, not_found_is_empty=True)
+
+    @property
+    def spend_limit_get(self):
+        """Get the current spend limit and usage for an organization.
+
+        Args:
+            org: Organization ID
+        Returns:
+            Dict with limitCents, currentSpendCents, periodStart, periodEnd,
+            blocked, blockedAt. Returns None if the endpoint reports 404.
+        """
+        return self.create_api_method(self._spend_limit_get)
+
+    async def _spend_limit_update(self, org: str, limit_cents: int | None) -> dict | None:
+        url = self.construct_api_url("spend_limit_path").format(org=org)
+        return await self._base_request("PUT", url, json={"limitCents": limit_cents})
+
+    @property
+    def spend_limit_update(self):
+        """Set or clear the organization spend limit.
+
+        Args:
+            org: Organization ID
+            limit_cents: New limit in cents, or None to clear the limit.
+        Returns:
+            The updated spend-limit response (same shape as spend_limit_get).
+        """
+        return self.create_api_method(self._spend_limit_update)
+
     # Builds
 
     async def _build_upload_url(self, org: str, region: str | None = None) -> dict:

--- a/src/pipecatcloud/cli/commands/spend_limit.py
+++ b/src/pipecatcloud/cli/commands/spend_limit.py
@@ -73,7 +73,7 @@ def _render_show(data: dict) -> None:
 
     spend_display = format_cents(spend_cents)
     # Skip the percentage when no limit is set, and when the limit is exactly
-    # $0 (which is a valid "block everything" state — guard against div-by-zero).
+    # $0 (a valid "block everything" state). Guards against div-by-zero.
     if limit_cents is not None and limit_cents > 0:
         pct = (spend_cents / limit_cents) * 100
         spend_display += f" [dim]({pct:.1f}%)[/dim]"

--- a/src/pipecatcloud/cli/commands/spend_limit.py
+++ b/src/pipecatcloud/cli/commands/spend_limit.py
@@ -1,0 +1,260 @@
+#
+# Copyright (c) 2025, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+from decimal import Decimal, InvalidOperation
+
+import questionary
+import typer
+from rich import box
+from rich.table import Table
+
+from pipecatcloud._utils.async_utils import synchronizer
+from pipecatcloud._utils.auth_utils import requires_login
+from pipecatcloud._utils.console_utils import console, format_cents, format_timestamp
+from pipecatcloud.cli.api import API
+from pipecatcloud.cli.config import config
+
+spend_limit_cli = typer.Typer(
+    name="spend-limit",
+    help="Manage the organization-level spend limit",
+    no_args_is_help=True,
+)
+
+
+def _parse_amount_to_cents(amount: str) -> int:
+    """Parse a user-supplied dollar amount into integer cents.
+
+    Accepts a non-negative number with at most two decimal places.
+    """
+    try:
+        dollars = Decimal(amount)
+    except InvalidOperation as e:
+        raise typer.BadParameter(
+            f"Invalid dollar amount: {amount!r}. Use a number like 50 or 12.34.",
+        ) from e
+
+    if dollars < 0:
+        raise typer.BadParameter("Amount must be zero or positive.")
+
+    cents = dollars * 100
+    if cents != cents.to_integral_value():
+        raise typer.BadParameter(
+            f"Dollar amount has more than two decimal places: {amount!r}.",
+        )
+    return int(cents)
+
+
+def _render_show(data: dict) -> None:
+    """Pretty-print the spend-limit payload for a human reader."""
+    limit_cents = data.get("limitCents")
+    spend_cents = data.get("currentSpendCents", 0) or 0
+    period_start = data.get("periodStart")
+    period_end = data.get("periodEnd")
+    blocked = bool(data.get("blocked"))
+    blocked_at = data.get("blockedAt")
+
+    table = Table(
+        show_header=False,
+        box=box.SIMPLE,
+        border_style="dim",
+        show_edge=True,
+        show_lines=False,
+    )
+    table.add_column("Field", style="cyan")
+    table.add_column("Value", style="white")
+
+    if limit_cents is None:
+        table.add_row("Limit", "[dim]no limit set[/dim]")
+    else:
+        table.add_row("Limit", format_cents(limit_cents))
+
+    spend_display = format_cents(spend_cents)
+    # Skip the percentage when no limit is set, and when the limit is exactly
+    # $0 (which is a valid "block everything" state — guard against div-by-zero).
+    if limit_cents is not None and limit_cents > 0:
+        pct = (spend_cents / limit_cents) * 100
+        spend_display += f" [dim]({pct:.1f}%)[/dim]"
+    table.add_row("Current spend", spend_display)
+
+    if period_start:
+        table.add_row("Period start", format_timestamp(period_start))
+    if period_end:
+        table.add_row("Period end", format_timestamp(period_end))
+
+    if blocked:
+        blocked_value = "[bold red]yes[/bold red]"
+        if blocked_at:
+            blocked_value += f" [dim](since {format_timestamp(blocked_at)})[/dim]"
+        table.add_row("Blocked", blocked_value)
+    else:
+        table.add_row("Blocked", "no")
+
+    console.success(table, title_extra="Spend limit")
+
+    if blocked:
+        console.print(
+            "[yellow]New sessions are being rejected. In-flight sessions continue to run.[/yellow]"
+        )
+
+
+@spend_limit_cli.command(name="show", help="Show the current spend limit and usage.")
+@synchronizer.create_blocking
+@requires_login
+async def show(
+    organization: str = typer.Option(
+        None,
+        "--organization",
+        "-o",
+        help="Organization to query (defaults to active org)",
+    ),
+    output_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Print raw JSON instead of a formatted table",
+    ),
+):
+    org = organization or config.get("org")
+
+    if output_json:
+        # Bubble errors so we don't print a rich panel before/instead of the JSON.
+        data, error = await API.bubble_error().spend_limit_get(org)
+        if error:
+            console.print_json(data={"error": error})
+            return typer.Exit(1)
+        if data is None:
+            console.print_json(data={})
+            return
+        console.print_json(data=data)
+        return
+
+    with console.status(
+        f"[dim]Fetching spend limit for organization: [bold]'{org}'[/bold][/dim]",
+        spinner="dots",
+    ):
+        data, error = await API.spend_limit_get(org)
+
+        if error:
+            return typer.Exit(1)
+
+    if data is None:
+        console.print("[dim]No spend-limit data available for this organization.[/dim]")
+        return
+
+    _render_show(data)
+
+
+@spend_limit_cli.command(name="set", help="Set or update the spend limit.")
+@synchronizer.create_blocking
+@requires_login
+async def set_limit(
+    amount: str = typer.Argument(
+        ...,
+        help="Limit in dollars (e.g. 50 or 12.34). At most two decimal places.",
+    ),
+    organization: str = typer.Option(
+        None,
+        "--organization",
+        "-o",
+        help="Organization to update (defaults to active org)",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompts.",
+    ),
+):
+    org = organization or config.get("org")
+    new_cents = _parse_amount_to_cents(amount)
+
+    # Fetch current state so we can warn on $0 limits and downgrades that
+    # would immediately block the org.
+    with console.status(
+        f"[dim]Checking current spend for organization: [bold]'{org}'[/bold][/dim]",
+        spinner="dots",
+    ):
+        current, error = await API.spend_limit_get(org)
+        if error:
+            return typer.Exit(1)
+
+    current_spend = (current or {}).get("currentSpendCents") or 0
+
+    if not yes:
+        if new_cents == 0:
+            confirm = await questionary.confirm(
+                "Setting the limit to $0.00 blocks all new sessions until you raise it. Continue?",
+                default=False,
+            ).ask_async()
+            if not confirm:
+                console.cancel()
+                return typer.Exit(1)
+        elif current_spend > new_cents:
+            confirm = await questionary.confirm(
+                f"Current spend ({format_cents(current_spend)}) exceeds the new limit "
+                f"({format_cents(new_cents)}). New sessions will be blocked. Continue?",
+                default=False,
+            ).ask_async()
+            if not confirm:
+                console.cancel()
+                return typer.Exit(1)
+
+    with console.status(
+        f"[dim]Setting spend limit to {format_cents(new_cents)}[/dim]",
+        spinner="dots",
+    ):
+        data, error = await API.spend_limit_update(org, new_cents)
+
+        if error:
+            return typer.Exit(1)
+
+    console.success(
+        f"Spend limit for [bold]'{org}'[/bold] set to "
+        f"[bold green]{format_cents(new_cents)}[/bold green]."
+    )
+    if data:
+        _render_show(data)
+
+
+@spend_limit_cli.command(name="clear", help="Remove the spend limit.")
+@synchronizer.create_blocking
+@requires_login
+async def clear(
+    organization: str = typer.Option(
+        None,
+        "--organization",
+        "-o",
+        help="Organization to update (defaults to active org)",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt.",
+    ),
+):
+    org = organization or config.get("org")
+
+    if not yes:
+        confirm = await questionary.confirm(
+            f"Remove the spend limit for '{org}'? New sessions will not be capped.",
+            default=False,
+        ).ask_async()
+        if not confirm:
+            console.cancel()
+            return typer.Exit(1)
+
+    with console.status(
+        f"[dim]Clearing spend limit for organization: [bold]'{org}'[/bold][/dim]",
+        spinner="dots",
+    ):
+        data, error = await API.spend_limit_update(org, None)
+
+        if error:
+            return typer.Exit(1)
+
+    console.success(f"Spend limit for [bold]'{org}'[/bold] cleared.")
+    if data:
+        _render_show(data)

--- a/src/pipecatcloud/cli/entry_point.py
+++ b/src/pipecatcloud/cli/entry_point.py
@@ -18,6 +18,7 @@ from pipecatcloud.cli.commands.docker import create_docker_command
 from pipecatcloud.cli.commands.organizations import organization_cli
 from pipecatcloud.cli.commands.regions import regions_cli
 from pipecatcloud.cli.commands.secrets import secrets_cli
+from pipecatcloud.cli.commands.spend_limit import spend_limit_cli
 from pipecatcloud.cli.config import config
 from pipecatcloud.exception import ConfigFileError
 
@@ -99,6 +100,7 @@ entrypoint_cli_typer.add_typer(build_cli, rich_help_panel="Commands")
 entrypoint_cli_typer.add_typer(organization_cli, rich_help_panel="Commands")
 entrypoint_cli_typer.add_typer(regions_cli, rich_help_panel="Commands")
 entrypoint_cli_typer.add_typer(secrets_cli, rich_help_panel="Commands")
+entrypoint_cli_typer.add_typer(spend_limit_cli, rich_help_panel="Commands")
 entrypoint_cli_typer.add_typer(agent_cli, rich_help_panel="Commands")
 
 entrypoint_cli = typer.main.get_command(entrypoint_cli_typer)

--- a/src/pipecatcloud/config.py
+++ b/src/pipecatcloud/config.py
@@ -38,6 +38,7 @@ _SETTINGS = {
     "secrets_path": _Setting("/v1/organizations/{org}/secrets"),
     "regions_path": _Setting("/v1/organizations/{org}/regions"),
     "properties_path": _Setting("/v1/organizations/{org}/properties"),
+    "spend_limit_path": _Setting("/v1/organizations/{org}/spend-limit"),
     "builds_path": _Setting("/v1/organizations/{org}/builds"),
 }
 

--- a/tests/test_spend_limit.py
+++ b/tests/test_spend_limit.py
@@ -122,6 +122,16 @@ class TestFormatCents:
     def test_none(self):
         assert format_cents(None) == "no limit"
 
+    def test_large_value_is_exact(self):
+        # Integer arithmetic must not lose precision the way float division
+        # could for very large cent counts.
+        assert format_cents(123_456_789_012_345) == "$1234567890123.45"
+
+    def test_negative(self):
+        # Not exercised in practice (parser rejects negatives), but the
+        # formatter should not produce something like "$-1.-23".
+        assert format_cents(-1234) == "-$12.34"
+
 
 # ---- SPEND_LIMIT_REACHED wrapping ----
 

--- a/tests/test_spend_limit.py
+++ b/tests/test_spend_limit.py
@@ -1,0 +1,327 @@
+"""Tests for the spend-limit CLI commands and API client methods."""
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import typer
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from pipecatcloud._utils.console_utils import PipecatConsole, format_cents
+from pipecatcloud.api import _API
+from pipecatcloud.cli.commands.spend_limit import (
+    _parse_amount_to_cents,
+    _render_show,
+    clear,
+    set_limit,
+    show,
+)
+
+# ---- API client ----
+
+
+class TestSpendLimitAPI:
+    @pytest.fixture
+    def api_client(self):
+        return _API(token="test-token", is_cli=True)
+
+    @pytest.mark.asyncio
+    async def test_get_calls_correct_path(self, api_client):
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {
+                "limitCents": 5000,
+                "currentSpendCents": 1234,
+                "periodStart": "2026-05-01T00:00:00Z",
+                "periodEnd": "2026-06-01T00:00:00Z",
+                "blocked": False,
+                "blockedAt": None,
+            }
+
+            result = await api_client._spend_limit_get(org="test-org")
+
+            assert result["limitCents"] == 5000
+            assert result["currentSpendCents"] == 1234
+            mock_request.assert_called_once()
+            args, kwargs = mock_request.call_args
+            assert args[0] == "GET"
+            assert args[1].endswith("/v1/organizations/test-org/spend-limit")
+            assert kwargs.get("not_found_is_empty") is True
+
+    @pytest.mark.asyncio
+    async def test_update_sends_put_with_limit_cents(self, api_client):
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"limitCents": 5000}
+
+            await api_client._spend_limit_update(org="test-org", limit_cents=5000)
+
+            mock_request.assert_called_once()
+            args, kwargs = mock_request.call_args
+            assert args[0] == "PUT"
+            assert args[1].endswith("/v1/organizations/test-org/spend-limit")
+            assert kwargs["json"] == {"limitCents": 5000}
+
+    @pytest.mark.asyncio
+    async def test_update_with_none_clears_limit(self, api_client):
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"limitCents": None}
+
+            await api_client._spend_limit_update(org="test-org", limit_cents=None)
+
+            args, kwargs = mock_request.call_args
+            assert kwargs["json"] == {"limitCents": None}
+
+
+# ---- Amount parsing ----
+
+
+class TestParseAmountToCents:
+    @pytest.mark.parametrize(
+        ("amount", "expected"),
+        [
+            ("0", 0),
+            ("1", 100),
+            ("50", 5000),
+            ("12.34", 1234),
+            ("0.50", 50),
+            ("0.05", 5),
+        ],
+    )
+    def test_dollar_amounts(self, amount, expected):
+        assert _parse_amount_to_cents(amount) == expected
+
+    def test_rejects_negative_dollars(self):
+        with pytest.raises(typer.BadParameter):
+            _parse_amount_to_cents("-5")
+
+    def test_rejects_more_than_two_decimal_places(self):
+        with pytest.raises(typer.BadParameter):
+            _parse_amount_to_cents("1.234")
+
+    def test_rejects_non_numeric(self):
+        with pytest.raises(typer.BadParameter):
+            _parse_amount_to_cents("abc")
+
+
+# ---- Cents formatting ----
+
+
+class TestFormatCents:
+    def test_round_dollars(self):
+        assert format_cents(5000) == "$50.00"
+
+    def test_sub_dollar(self):
+        assert format_cents(5) == "$0.05"
+
+    def test_zero(self):
+        assert format_cents(0) == "$0.00"
+
+    def test_none(self):
+        assert format_cents(None) == "no limit"
+
+
+# ---- SPEND_LIMIT_REACHED wrapping ----
+
+
+class TestSpendLimitReachedRendering:
+    """Verify that api_error renders the wrapped remediation message."""
+
+    def _render(self, error: dict) -> str:
+        buffer = StringIO()
+        # force_terminal=False so Rich does not emit color codes that would
+        # complicate substring matching.
+        console = PipecatConsole(file=buffer, force_terminal=False, width=120)
+        console.api_error(error)
+        return buffer.getvalue()
+
+    def test_includes_usage_when_fields_present(self):
+        output = self._render(
+            {
+                "error": "Spend limit reached",
+                "code": "SPEND_LIMIT_REACHED",
+                "limitCents": 5000,
+                "currentSpendCents": 5234,
+            }
+        )
+        assert "spend limit" in output.lower()
+        assert "$52.34" in output
+        assert "$50.00" in output
+        assert "spend-limit set" in output
+        assert "spend-limit clear" in output
+
+    def test_falls_back_without_fields(self):
+        output = self._render(
+            {
+                "error": "Spend limit reached",
+                "code": "SPEND_LIMIT_REACHED",
+            }
+        )
+        assert "spend limit" in output.lower()
+        assert "spend-limit set" in output
+
+    def test_generic_error_unchanged(self):
+        output = self._render(
+            {
+                "error": "Bad request",
+                "code": "BAD_REQUEST",
+            }
+        )
+        assert "spend-limit set" not in output
+        assert "Bad request" in output
+
+
+# ---- CLI command surfaces ----
+#
+# These tests exercise the sync wrappers produced by @synchronizer.create_blocking,
+# matching the pattern in test_agent_stop.py.
+
+
+class TestRenderShow:
+    """Direct render tests guard against divide-by-zero and missing-field issues."""
+
+    def test_zero_limit_does_not_divide_by_zero(self, capsys):
+        # Should not raise. $0 is a valid "block everything" state and we want
+        # the limit to render even though we cannot compute a percentage.
+        _render_show(
+            {
+                "limitCents": 0,
+                "currentSpendCents": 0,
+                "blocked": False,
+            }
+        )
+        out = capsys.readouterr().out
+        assert "$0.00" in out
+
+    def test_no_limit_renders_without_percentage(self, capsys):
+        _render_show(
+            {
+                "limitCents": None,
+                "currentSpendCents": 0,
+                "blocked": False,
+            }
+        )
+        out = capsys.readouterr().out
+        assert "no limit set" in out
+        # The percent suffix should not appear without a positive limit.
+        assert "%" not in out
+
+
+class TestSpendLimitShowCommand:
+    def test_show_json_prints_payload(self, capsys):
+        payload = {
+            "limitCents": 5000,
+            "currentSpendCents": 1234,
+            "periodStart": "2026-05-01T00:00:00Z",
+            "periodEnd": "2026-06-01T00:00:00Z",
+            "blocked": False,
+            "blockedAt": None,
+        }
+
+        mock_api = MagicMock()
+        mock_api.bubble_error.return_value = mock_api
+        mock_api.spend_limit_get = AsyncMock(return_value=(payload, None))
+
+        with patch("pipecatcloud.cli.commands.spend_limit.API", mock_api):
+            show(organization="test-org", output_json=True)
+
+        captured = capsys.readouterr().out
+        assert json.loads(captured) == payload
+
+
+class TestSpendLimitSetCommand:
+    def test_set_skips_prompt_when_yes_flag(self):
+        mock_api = MagicMock()
+        mock_api.spend_limit_get = AsyncMock(return_value=({"currentSpendCents": 0}, None))
+        mock_api.spend_limit_update = AsyncMock(return_value=({"limitCents": 5000}, None))
+
+        with (
+            patch("pipecatcloud.cli.commands.spend_limit.API", mock_api),
+            patch("pipecatcloud.cli.commands.spend_limit.questionary") as mock_q,
+        ):
+            set_limit(
+                amount="50",
+                organization="test-org",
+                yes=True,
+            )
+
+            mock_q.confirm.assert_not_called()
+            mock_api.spend_limit_update.assert_awaited_once_with("test-org", 5000)
+
+    def test_set_aborts_when_downgrade_rejected(self):
+        mock_api = MagicMock()
+        mock_api.spend_limit_get = AsyncMock(return_value=({"currentSpendCents": 10000}, None))
+        mock_api.spend_limit_update = AsyncMock()
+
+        with (
+            patch("pipecatcloud.cli.commands.spend_limit.API", mock_api),
+            patch("pipecatcloud.cli.commands.spend_limit.questionary") as mock_q,
+        ):
+            mock_q.confirm.return_value.ask_async = AsyncMock(return_value=False)
+
+            result = set_limit(
+                amount="50",
+                organization="test-org",
+                yes=False,
+            )
+
+            mock_q.confirm.assert_called_once()
+            mock_api.spend_limit_update.assert_not_called()
+            assert isinstance(result, typer.Exit)
+            assert result.exit_code == 1
+
+    def test_set_aborts_when_zero_rejected(self):
+        mock_api = MagicMock()
+        mock_api.spend_limit_get = AsyncMock(return_value=({"currentSpendCents": 0}, None))
+        mock_api.spend_limit_update = AsyncMock()
+
+        with (
+            patch("pipecatcloud.cli.commands.spend_limit.API", mock_api),
+            patch("pipecatcloud.cli.commands.spend_limit.questionary") as mock_q,
+        ):
+            mock_q.confirm.return_value.ask_async = AsyncMock(return_value=False)
+
+            result = set_limit(
+                amount="0",
+                organization="test-org",
+                yes=False,
+            )
+
+            mock_q.confirm.assert_called_once()
+            mock_api.spend_limit_update.assert_not_called()
+            assert isinstance(result, typer.Exit)
+            assert result.exit_code == 1
+
+
+class TestSpendLimitClearCommand:
+    def test_clear_skips_prompt_when_yes_flag(self):
+        mock_api = MagicMock()
+        mock_api.spend_limit_update = AsyncMock(return_value=({"limitCents": None}, None))
+
+        with (
+            patch("pipecatcloud.cli.commands.spend_limit.API", mock_api),
+            patch("pipecatcloud.cli.commands.spend_limit.questionary") as mock_q,
+        ):
+            clear(organization="test-org", yes=True)
+
+            mock_q.confirm.assert_not_called()
+            mock_api.spend_limit_update.assert_awaited_once_with("test-org", None)
+
+    def test_clear_aborts_when_user_rejects(self):
+        mock_api = MagicMock()
+        mock_api.spend_limit_update = AsyncMock()
+
+        with (
+            patch("pipecatcloud.cli.commands.spend_limit.API", mock_api),
+            patch("pipecatcloud.cli.commands.spend_limit.questionary") as mock_q,
+        ):
+            mock_q.confirm.return_value.ask_async = AsyncMock(return_value=False)
+
+            result = clear(organization="test-org", yes=False)
+
+            mock_q.confirm.assert_called_once()
+            mock_api.spend_limit_update.assert_not_called()
+            assert isinstance(result, typer.Exit)
+            assert result.exit_code == 1


### PR DESCRIPTION
## Summary

- New `pcc spend-limit` command group: `show` (with `--json`), `set <dollars>`, and `clear`. Confirmation prompts guard against blocking all new sessions ($0 limit or downgrade below current spend); `-y/--yes` skips them.
- Wraps any HTTP 402 + `code: SPEND_LIMIT_REACHED` API response in a remediation panel that points at the new commands, so commands like `pcc agent start` no longer surface a generic API error when the cap is hit.
- Adds `_API.spend_limit_get` / `spend_limit_update` against the Phase 2 `GET/PUT /v1/organizations/:id/spend-limit` endpoints.

## Test plan

- [x] `uv run pytest` (225 passing, 27 new)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format` clean
- [x] `pcc spend-limit --help` and `pcc spend-limit set --help` render the expected surface
- [x] Drive `show` / `set` / `clear` against staging in various states (no limit, limit set, near-limit, blocked)
- [ ] Trigger a 402 from `pcc agent start` against a blocked org and confirm the wrapped panel renders with usage values

PCC-807: https://linear.app/dailyco/issue/PCC-807/spend-limits-phase-6-cli