### PR TITLE
fix: update stale docs.pipecat.daily.co links to docs.pipecat.ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated stale documentation links that pointed at the retired
   `docs.pipecat.daily.co` domain. The API error panel now links to the
   error codes reference at
-  `https://docs.pipecat.ai/pipecat-cloud/fundamentals/error-codes` (the old
-  link redirected to a generic landing page, and the `#<code>` anchor never
-  resolved for plain HTTP status codes). The deploy and image pull secret
-  prompts now link to
+  `https://docs.pipecat.ai/pipecat-cloud/fundamentals/error-codes#<code>`,
+  with the code lowercased to match the page's heading anchors (the old
+  link redirected to a generic landing page). The deploy and image pull
+  secret prompts now link to
   `https://docs.pipecat.ai/pipecat-cloud/fundamentals/secrets#image-pull-secrets`.
 
 ## [1.0.0] - 2026-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Updated stale documentation links that pointed at the retired
+  `docs.pipecat.daily.co` domain. The API error panel now links to the
+  error codes reference at
+  `https://docs.pipecat.ai/pipecat-cloud/fundamentals/error-codes` (the old
+  link redirected to a generic landing page, and the `#<code>` anchor never
+  resolved for plain HTTP status codes). The deploy and image pull secret
+  prompts now link to
+  `https://docs.pipecat.ai/pipecat-cloud/fundamentals/secrets#image-pull-secrets`.
+
 ## [1.0.0] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   link redirected to a generic landing page). The deploy and image pull
   secret prompts now link to
   `https://docs.pipecat.ai/pipecat-cloud/fundamentals/secrets#image-pull-secrets`.
+  The README docs badge and link, the `pyproject.toml` project Website URL,
+  and the `CLAUDE.md` public docs pointer now use
+  `https://docs.pipecat.ai/pipecat-cloud` as well.
 
 ## [1.0.0] - 2026-06-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Guidance for Claude Code working in this repo.
 
 - Package root: `src/pipecatcloud/`
 - CLI: registered as a Pipecat CLI extension via the `pipecat_cli.extensions:cloud` entry point (surfaced as `pipecat cloud`). There is no standalone entry point — no `[project.scripts]` and no `__main__`; the CLI runs only through the Pipecat CLI.
-- Public docs: https://docs.pipecat.daily.co
+- Public docs: https://docs.pipecat.ai/pipecat-cloud
 
 ## Toolchain
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
  <img alt="pipecat cloud" width="500px" height="auto" src="https://raw.githubusercontent.com/daily-co/pipecat-cloud/main/pipecat-cloud.png">
 </div></h1>
 
-[![Docs](https://img.shields.io/badge/documentation-blue)](https://docs.pipecat.daily.co)
+[![Docs](https://img.shields.io/badge/documentation-blue)](https://docs.pipecat.ai/pipecat-cloud)
 [![PyPI](https://img.shields.io/pypi/v/pipecatcloud)](https://pypi.org/project/pipecatcloud)
 
 # Pipecat Cloud
@@ -18,7 +18,7 @@ Python module and CLI for interacting with [Pipecat Cloud](https://pipecat.daily
 
 ### Documentation
 
-Documentation for Pipecat Cloud is available [here](https://docs.pipecat.daily.co).
+Documentation for Pipecat Cloud is available [here](https://docs.pipecat.ai/pipecat-cloud).
 
 ### Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ select = [
 "**/__init__.py" = ["D104"]
 
 [project.urls]
-Website = "https://docs.pipecat.daily.co/"
+Website = "https://docs.pipecat.ai/pipecat-cloud"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"

--- a/src/pipecatcloud/_utils/console_utils.py
+++ b/src/pipecatcloud/_utils/console_utils.py
@@ -116,7 +116,7 @@ class PipecatConsole(Console):
             Panel(
                 f"[red]{title}[/red]\n\n[dim]Error message:[/dim]\n{error_message}",
                 title=f"[bold red]{PANEL_TITLE_ERROR}{f' - {code}' if code else ''}[/bold red]",
-                subtitle=f"[dim]Docs: https://docs.pipecat.daily.co/agents/error-codes#{code}[/dim]"
+                subtitle="[dim]Docs: https://docs.pipecat.ai/pipecat-cloud/fundamentals/error-codes[/dim]"
                 if not hide_subtitle and code
                 else None,
                 title_align="left",

--- a/src/pipecatcloud/_utils/console_utils.py
+++ b/src/pipecatcloud/_utils/console_utils.py
@@ -116,7 +116,7 @@ class PipecatConsole(Console):
             Panel(
                 f"[red]{title}[/red]\n\n[dim]Error message:[/dim]\n{error_message}",
                 title=f"[bold red]{PANEL_TITLE_ERROR}{f' - {code}' if code else ''}[/bold red]",
-                subtitle="[dim]Docs: https://docs.pipecat.ai/pipecat-cloud/fundamentals/error-codes[/dim]"
+                subtitle=f"[dim]Docs: https://docs.pipecat.ai/pipecat-cloud/fundamentals/error-codes#{str(code).lower()}[/dim]"
                 if not hide_subtitle and code
                 else None,
                 title_align="left",

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -777,7 +777,7 @@ def create_deploy_command(app: typer.Typer):
             console.error(
                 "Deployments require an image pull secret [bold](--credentials)[/bold] to securely pull images from private repositories."
                 "\nPlease provide an image pull secret name or use [bold][--no-credentials][/bold] to deploy without one.",
-                subtitle="Learn more:https://docs.pipecat.daily.co/agents/secrets#image-pull-secrets",
+                subtitle="Learn more: https://docs.pipecat.ai/pipecat-cloud/fundamentals/secrets#image-pull-secrets",
                 title_extra="Attempt to deploy without repository credentials",
             )
             return typer.Exit()

--- a/src/pipecatcloud/cli/commands/secrets.py
+++ b/src/pipecatcloud/cli/commands/secrets.py
@@ -567,7 +567,7 @@ async def image_pull_secret(
     if not credentials:
         console.print(
             "[cyan]For more information about image pull secrets, see: "
-            "https://docs.pipecat.daily.co/agents/secrets#image-pull-secrets[/cyan]\n"
+            "https://docs.pipecat.ai/pipecat-cloud/fundamentals/secrets#image-pull-secrets[/cyan]\n"
         )
         username = await questionary.text(f"Username for image repository '{host}'").ask_async()
         password = await questionary.password(


### PR DESCRIPTION
## What

Replaces three hardcoded links to the retired `docs.pipecat.daily.co` domain with their current `docs.pipecat.ai` equivalents:

- `_utils/console_utils.py`: the API error panel footer now links to `https://docs.pipecat.ai/pipecat-cloud/fundamentals/error-codes#<code>`, with the code lowercased so it matches the page's heading anchors (e.g. `PCC-1004` -> `#pcc-1004`).
- `cli/commands/deploy.py` and `cli/commands/secrets.py`: image pull secret guidance now links to https://docs.pipecat.ai/pipecat-cloud/fundamentals/secrets#image-pull-secrets. Also fixes the missing space after "Learn more:".

## Why

A customer hit a 400 "Invalid parameters" on `deploy` and reported that the docs link in the error panel does not work (Plain ticket T-2712). The old domain redirects to a generic landing page, so the one link we show at the exact moment someone is stuck goes nowhere useful.

## Notes

- For plain HTTP errors `code` is the status string (e.g. `400`), so the anchor is `#400`, which has no heading on the page. The browser just lands at the top of the error-codes reference, which is still the right page.
- Anchor scheme verified against the live page: heading ids are the code lowercased with underscores preserved (`#pcc-1004`, `#pcc_image_not_found`), so `str(code).lower()` matches every documented code.
- CHANGELOG updated under Unreleased.
- Follow-ups worth separate PRs (not included here): surface the Zod `issues` details from 400 bodies instead of just "Invalid parameters", and validate the agent name locally before sending.
