### PR TITLE
Add 'secrets reference' for self-hosted regions (PCC-1021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resources and `--profile` are mutually exclusive, and the API accepts
   explicit resources only for agents in self-hosted regions.
 
+- `pipecat cloud agent status` now shows the agent's resolved resources
+  (cpu/memory) from the deployment. For agents deployed with explicit
+  resources rather than a profile, this is the sizing surface.
+
 - New `pipecat cloud agent profiles` command group. `list` shows the platform
   catalog plus any profiles your organization has defined; `create`, `update`,
   `disable`, and `enable` manage organization-defined profiles for self-hosted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New `pipecat cloud secrets reference <name> --region <region>` command for
+  **self-hosted regions**. It registers an existing Kubernetes Secret from your
+  workloads namespace as a secret set, so agents can use it by set name exactly
+  as they use managed sets, and the Kubernetes Secret's name becomes the secret
+  set name. The secret stays in your cluster: Pipecat Cloud records only its
+  name, region, and readiness, never its values or keys, and you keep managing
+  its contents with your own tooling such as `kubectl`. `--region` is required
+  and must name a self-hosted region; cloud regions are rejected.
+
 ## [1.1.0] - 2026-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resources and `--profile` are mutually exclusive, and the API accepts
   explicit resources only for agents in self-hosted regions.
 
-- New `pipecat cloud agent-profiles` command group. `list` shows the platform
+- New `pipecat cloud agent profiles` command group. `list` shows the platform
   catalog plus any profiles your organization has defined; `create`, `update`,
-  and `disable` manage organization-defined profiles for self-hosted regions.
-  Profile edits apply to future deploys only: running agents keep the
-  resources their deployment captured.
+  `disable`, and `enable` manage organization-defined profiles for self-hosted
+  regions. Profile edits apply to future deploys only: running agents keep the
+  resources their deployment captured. Disabling is reversible: a disabled
+  profile can't be selected for new deploys until re-enabled.
 
 - New `pipecat cloud secrets reference <name> --region <region>` command for
   **self-hosted regions**. It registers an existing Kubernetes Secret from your

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Explicit agent sizing for **enterprise (self-hosted) regions**. Deploys can
+  now state resources directly instead of selecting an agent profile:
+  `pipecat cloud deploy --resources cpu=2,memory=4Gi`, or a `[resources]`
+  section in `pcc-deploy.toml` with `cpu` and `memory` keys. Explicit
+  resources and `--profile` are mutually exclusive, and the API accepts
+  explicit resources only for agents in self-hosted regions.
+
+- New `pipecat cloud agent-profiles` command group. `list` shows the platform
+  catalog plus any profiles your organization has defined; `create`, `update`,
+  and `disable` manage organization-defined profiles for self-hosted regions.
+  Profile edits apply to future deploys only: running agents keep the
+  resources their deployment captured.
+
 - New `pipecat cloud secrets reference <name> --region <region>` command for
   **self-hosted regions**. It registers an existing Kubernetes Secret from your
   workloads namespace as a secret set, so agents can use it by set name exactly

--- a/src/pipecatcloud/_utils/deploy_utils.py
+++ b/src/pipecatcloud/_utils/deploy_utils.py
@@ -301,6 +301,61 @@ class KrispVivaConfig:
         return {"audio_filter": self.audio_filter}
 
 
+# Mirrors the server-side k8s quantity validation (positive decimal + optional
+# suffix). Kept client-side so a typo fails before any network round-trip.
+K8S_QUANTITY_PATTERN = r"^[0-9]+(\.[0-9]+)?(m|k|M|G|T|P|E|Ki|Mi|Gi|Ti|Pi|Ei)?$"
+
+
+@dataclass
+class ResourcesConfig:
+    """Explicit sizing for agents in enterprise (self-hosted) regions.
+
+    Mutually exclusive with agent_profile: a deploy either references a named
+    profile or states cpu/memory directly. Only accepted by the API for
+    services in self-hosted regions.
+    """
+
+    cpu: str | None = None
+    memory: str | None = None
+
+    def __attrs_post_init__(self):
+        import re
+
+        if (self.cpu is None) != (self.memory is None):
+            raise ValueError("resources requires both 'cpu' and 'memory'")
+        for name, value in (("cpu", self.cpu), ("memory", self.memory)):
+            if value is not None and not re.match(K8S_QUANTITY_PATTERN, str(value)):
+                raise ValueError(
+                    f"Invalid {name} quantity '{value}' (expected e.g. '500m', '2', '4Gi')"
+                )
+
+    def is_set(self) -> bool:
+        return self.cpu is not None
+
+    def to_dict(self):
+        return {"cpu": self.cpu, "memory": self.memory}
+
+
+def parse_resources_option(value: str) -> "ResourcesConfig | None":
+    """Parse the --resources CLI value ("cpu=2,memory=4Gi") into a ResourcesConfig.
+
+    Returns None on malformed input (unknown keys, missing cpu/memory, bad
+    quantities) so the caller can print a usable error instead of a traceback.
+    """
+    parts: dict[str, str] = {}
+    for chunk in value.split(","):
+        key, sep, val = chunk.partition("=")
+        if not sep or not val.strip():
+            return None
+        parts[key.strip()] = val.strip()
+    if set(parts.keys()) != {"cpu", "memory"}:
+        return None
+    try:
+        return ResourcesConfig(cpu=parts["cpu"], memory=parts["memory"])
+    except ValueError:
+        return None
+
+
 @dataclass
 class BuildConfig:
     """Configuration for cloud builds."""
@@ -329,6 +384,7 @@ class DeployConfigParams:
     docker_config: dict = field(factory=dict)
     build_config: BuildConfig = field(factory=BuildConfig)  # Cloud build configuration
     agent_profile: str | None = None
+    resources: ResourcesConfig = field(factory=ResourcesConfig)
     krisp_viva: KrispVivaConfig = field(factory=KrispVivaConfig)
     force_redeploy: bool = False
     websocket_auth: str | None = None
@@ -342,6 +398,10 @@ class DeployConfigParams:
             raise ValueError("Cannot specify both 'image' and 'build_id'")
         if self.max_session_duration is not None and not 60 <= self.max_session_duration <= 14400:
             raise ValueError("max_session_duration must be between 60 and 14400 seconds")
+        # Sizing is one of: a named profile, or explicit resources (enterprise
+        # regions). The API enforces this too; failing here is just faster.
+        if self.agent_profile is not None and self.resources.is_set():
+            raise ValueError("Cannot specify both 'agent_profile' and 'resources'")
 
     def to_dict(self):
         return {
@@ -355,6 +415,7 @@ class DeployConfigParams:
             "docker_config": self.docker_config,
             "build_config": self.build_config.to_dict() if self.build_config else None,
             "agent_profile": self.agent_profile,
+            "resources": self.resources.to_dict() if self.resources.is_set() else None,
             "krisp_viva": self.krisp_viva.to_dict() if self.krisp_viva else None,
             "websocket_auth": self.websocket_auth,
             "max_session_duration": self.max_session_duration,
@@ -385,6 +446,10 @@ def load_deploy_config_file() -> DeployConfigParams | None:
         krisp_viva_data = config_data.pop("krisp_viva", {})
         krisp_viva_config = KrispVivaConfig(**krisp_viva_data)
 
+        # Extract explicit resources if present (enterprise regions)
+        resources_data = config_data.pop("resources", {})
+        resources_config = ResourcesConfig(**resources_data)
+
         # Extract build configuration if present
         build_data = config_data.pop("build", {})
         exclude_data = build_data.pop("exclude", {})
@@ -410,6 +475,7 @@ def load_deploy_config_file() -> DeployConfigParams | None:
             "krisp_viva",
             "websocket_auth",
             "max_session_duration",
+            "resources",
         }
 
         # TODO: Remove this enable_krisp migration hint in the 2.0.0 release.
@@ -429,6 +495,7 @@ def load_deploy_config_file() -> DeployConfigParams | None:
             docker_config=docker_data,
             build_config=build_config,
             krisp_viva=krisp_viva_config,
+            resources=resources_config,
         )
 
         return validated_config

--- a/src/pipecatcloud/_utils/deploy_utils.py
+++ b/src/pipecatcloud/_utils/deploy_utils.py
@@ -336,24 +336,29 @@ class ResourcesConfig:
         return {"cpu": self.cpu, "memory": self.memory}
 
 
-def parse_resources_option(value: str) -> "ResourcesConfig | None":
+def parse_resources_option(value: str) -> "ResourcesConfig":
     """Parse the --resources CLI value ("cpu=2,memory=4Gi") into a ResourcesConfig.
 
-    Returns None on malformed input (unknown keys, missing cpu/memory, bad
-    quantities) so the caller can print a usable error instead of a traceback.
+    Raises ValueError with a specific message on malformed input (unknown keys,
+    missing cpu/memory, bad quantities) so the caller can surface exactly what
+    was wrong rather than a generic usage error.
     """
     parts: dict[str, str] = {}
     for chunk in value.split(","):
         key, sep, val = chunk.partition("=")
         if not sep or not val.strip():
-            return None
+            raise ValueError(
+                f"Malformed --resources segment '{chunk.strip()}'. "
+                "Expected key=value pairs, e.g. cpu=2,memory=4Gi"
+            )
         parts[key.strip()] = val.strip()
     if set(parts.keys()) != {"cpu", "memory"}:
-        return None
-    try:
-        return ResourcesConfig(cpu=parts["cpu"], memory=parts["memory"])
-    except ValueError:
-        return None
+        raise ValueError(
+            "--resources requires exactly 'cpu' and 'memory', "
+            f"got: {', '.join(sorted(parts.keys())) or 'nothing'}"
+        )
+    # ResourcesConfig raises its own specific ValueError for bad quantities.
+    return ResourcesConfig(cpu=parts["cpu"], memory=parts["memory"])
 
 
 @dataclass

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -448,6 +448,91 @@ class _API:
         """
         return self.create_api_method(self._secrets_delete_set)
 
+    # Agent profiles
+
+    async def _agent_profiles_list(self, org: str) -> dict:
+        url = self.construct_api_url("agent_profiles_path").format(org=org)
+        return await self._base_request("GET", url) or {}
+
+    @property
+    def agent_profiles_list(self):
+        """List agent profiles visible to the organization.
+
+        Returns the platform catalog plus any profiles the organization has
+        defined (enterprise / self-hosted regions). Custom profiles are marked
+        with ``custom: true``.
+
+        Args:
+            org: Organization ID
+        """
+        return self.create_api_method(self._agent_profiles_list)
+
+    async def _agent_profiles_create(
+        self, api_name: str, display_name: str, cpu: str, memory: str, org: str
+    ) -> dict:
+        url = self.construct_api_url("agent_profiles_path").format(org=org)
+        return (
+            await self._base_request(
+                "POST",
+                url,
+                json={
+                    "apiName": api_name,
+                    "displayName": display_name,
+                    "resources": {"cpu": cpu, "memory": memory},
+                },
+            )
+            or {}
+        )
+
+    @property
+    def agent_profiles_create(self):
+        """Create an organization-defined agent profile (enterprise regions only).
+
+        Args:
+            api_name: Profile name used at deploy time (lowercase, hyphens)
+            display_name: Human-readable name
+            cpu: k8s cpu quantity, e.g. "2" or "500m"
+            memory: k8s memory quantity, e.g. "4Gi"
+            org: Organization ID
+        """
+        return self.create_api_method(self._agent_profiles_create)
+
+    async def _agent_profiles_update(
+        self,
+        api_name: str,
+        org: str,
+        display_name: str | None = None,
+        cpu: str | None = None,
+        memory: str | None = None,
+        enabled: bool | None = None,
+    ) -> dict:
+        url = f"{self.construct_api_url('agent_profiles_path').format(org=org)}/{api_name}"
+        payload: dict = {}
+        if display_name is not None:
+            payload["displayName"] = display_name
+        if cpu is not None and memory is not None:
+            payload["resources"] = {"cpu": cpu, "memory": memory}
+        if enabled is not None:
+            payload["enabled"] = enabled
+        return await self._base_request("PATCH", url, json=payload) or {}
+
+    @property
+    def agent_profiles_update(self):
+        """Update or disable an organization-defined agent profile.
+
+        Edits apply to future deploys only; running agents keep the resources
+        their deployment snapshotted. Disabling (enabled=False) is how a
+        profile is removed: history stays intact and the name can be recreated.
+
+        Args:
+            api_name: Profile name to update
+            org: Organization ID
+            display_name: New display name (optional)
+            cpu / memory: New sizing, both required together (optional)
+            enabled: Set False to disable (optional)
+        """
+        return self.create_api_method(self._agent_profiles_update)
+
     # Deploy
 
     async def _deploy(
@@ -466,6 +551,9 @@ class _API:
                 "maxAgents": deploy_config.scaling.max_agents,
             },
             "agentProfile": deploy_config.agent_profile,
+            "resources": (
+                deploy_config.resources.to_dict() if deploy_config.resources.is_set() else None
+            ),
             "krispViva": {
                 "audioFilter": deploy_config.krisp_viva.audio_filter,
             },

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -402,6 +402,25 @@ class _API:
         """
         return self.create_api_method(self._secrets_upsert)
 
+    async def _secrets_reference(self, name: str, region: str, org: str) -> dict:
+        url = f"{self.construct_api_url('secrets_path').format(org=org)}/references"
+        return await self._base_request("POST", url, json={"name": name, "region": region}) or {}
+
+    @property
+    def secrets_reference(self):
+        """Reference an existing Kubernetes Secret in a self-hosted region.
+
+        The secret stays in the customer's cluster; Pipecat Cloud stores only its
+        name, region, and readiness (never values or keys). Enterprise /
+        self-hosted regions only — the server rejects cloud regions.
+
+        Args:
+            name: name of the Kubernetes Secret (becomes the secret set name)
+            region: self-hosted region containing the secret
+            org: Organization ID
+        """
+        return self.create_api_method(self._secrets_reference)
+
     async def _secrets_delete(self, set_name: str, secret_name: str, org: str) -> dict | None:
         url = f"{self.construct_api_url('secrets_path').format(org=org)}/{set_name}/{secret_name}"
         return await self._base_request("DELETE", url, not_found_is_empty=True)

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -272,6 +272,16 @@ async def status(
                 str(agent_profile),
             )
 
+        # Resolved sizing from the deployment manifest. For an agent deployed
+        # with explicit resources (enterprise regions), there is no profile —
+        # this row is its only visible sizing.
+        resources = data.get("resources")
+        if resources and isinstance(resources, dict):
+            deployment_table.add_row(
+                "[bold]Resources:[/bold]",
+                f"cpu={resources.get('cpu', 'N/A')}, memory={resources.get('memory', 'N/A')}",
+            )
+
         deployment_table.add_row(
             "[bold]Active Deployment ID:[/bold]",
             str(data.get("activeDeploymentId", "N/A")),

--- a/src/pipecatcloud/cli/commands/agent_profiles.py
+++ b/src/pipecatcloud/cli/commands/agent_profiles.py
@@ -1,0 +1,188 @@
+#
+# Copyright (c) 2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import typer
+from rich.table import Table
+
+from pipecatcloud._utils.async_utils import synchronizer
+from pipecatcloud._utils.auth_utils import requires_login
+from pipecatcloud._utils.console_utils import console
+from pipecatcloud._utils.deploy_utils import ResourcesConfig
+from pipecatcloud.cli.api import API
+from pipecatcloud.cli.config import config
+
+agent_profiles_cli = typer.Typer(
+    name="agent-profiles",
+    help=(
+        "Agent profile management. The platform catalog is read-only; "
+        "organizations with enterprise (self-hosted) regions can define their "
+        "own profiles for use in those regions."
+    ),
+    no_args_is_help=True,
+)
+
+
+def _validate_sizing(cpu: str, memory: str) -> bool:
+    """Client-side quantity check so a typo fails before the network call."""
+    try:
+        ResourcesConfig(cpu=cpu, memory=memory)
+        return True
+    except ValueError as e:
+        console.error(str(e))
+        return False
+
+
+@agent_profiles_cli.command(name="list", help="List agent profiles available to your organization")
+@synchronizer.create_blocking
+@requires_login
+async def list_profiles(
+    organization: str = typer.Option(
+        None, "--organization", "-o", help="Organization to list profiles for"
+    ),
+):
+    org = organization or config.get("org")
+
+    with console.status("[dim]Fetching agent profiles...[/dim]", spinner="dots"):
+        data, error = await API.agent_profiles_list(org=org)
+
+    if error:
+        return typer.Exit(1)
+
+    profiles = (data or {}).get("agentProfiles", [])
+    if not profiles:
+        console.print("[yellow]No agent profiles available[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name")
+    table.add_column("Display name")
+    table.add_column("CPU")
+    table.add_column("Memory")
+    table.add_column("Source")
+    table.add_column("Enabled")
+
+    for profile in profiles:
+        resources = profile.get("resources") or {}
+        table.add_row(
+            profile.get("api_name", ""),
+            profile.get("display_name", ""),
+            str(resources.get("cpu", "")),
+            str(resources.get("memory", "")),
+            "custom" if profile.get("custom") else "platform",
+            "yes" if profile.get("enabled", True) else "[dim]no[/dim]",
+        )
+
+    console.print(table)
+
+
+@agent_profiles_cli.command(
+    name="create",
+    help="Create a custom agent profile (enterprise / self-hosted regions only)",
+)
+@synchronizer.create_blocking
+@requires_login
+async def create_profile(
+    name: str = typer.Argument(help="Profile name used at deploy time e.g. 'telephony-large'"),
+    cpu: str = typer.Option(..., "--cpu", help="CPU quantity e.g. '2' or '500m'"),
+    memory: str = typer.Option(..., "--memory", help="Memory quantity e.g. '4Gi'"),
+    display_name: str = typer.Option(
+        None, "--display-name", help="Human-readable name (defaults to the profile name)"
+    ),
+    organization: str = typer.Option(
+        None, "--organization", "-o", help="Organization to create the profile in"
+    ),
+):
+    org = organization or config.get("org")
+
+    if not _validate_sizing(cpu, memory):
+        return typer.Exit(1)
+
+    with console.status(f"[dim]Creating agent profile '{name}'...[/dim]", spinner="dots"):
+        data, error = await API.agent_profiles_create(
+            api_name=name,
+            display_name=display_name or name,
+            cpu=cpu,
+            memory=memory,
+            org=org,
+        )
+
+    if error:
+        return typer.Exit(1)
+
+    console.success(
+        f"Created agent profile '{name}' (cpu={cpu}, memory={memory}). "
+        f"Use it with: deploy --profile {name}"
+    )
+
+
+@agent_profiles_cli.command(
+    name="update",
+    help="Update a custom agent profile. Changes apply to future deploys only.",
+)
+@synchronizer.create_blocking
+@requires_login
+async def update_profile(
+    name: str = typer.Argument(help="Profile name to update"),
+    cpu: str = typer.Option(None, "--cpu", help="New CPU quantity (requires --memory)"),
+    memory: str = typer.Option(None, "--memory", help="New memory quantity (requires --cpu)"),
+    display_name: str = typer.Option(None, "--display-name", help="New human-readable name"),
+    organization: str = typer.Option(
+        None, "--organization", "-o", help="Organization the profile belongs to"
+    ),
+):
+    org = organization or config.get("org")
+
+    if (cpu is None) != (memory is None):
+        console.error("--cpu and --memory must be provided together")
+        return typer.Exit(1)
+    if cpu is None and display_name is None:
+        console.error("Nothing to update. Provide --cpu/--memory and/or --display-name.")
+        return typer.Exit(1)
+    if cpu is not None and not _validate_sizing(cpu, memory):
+        return typer.Exit(1)
+
+    with console.status(f"[dim]Updating agent profile '{name}'...[/dim]", spinner="dots"):
+        data, error = await API.agent_profiles_update(
+            api_name=name,
+            org=org,
+            display_name=display_name,
+            cpu=cpu,
+            memory=memory,
+        )
+
+    if error:
+        return typer.Exit(1)
+
+    console.success(
+        f"Updated agent profile '{name}'. Running agents keep their current "
+        "resources; changes apply on the next deploy."
+    )
+
+
+@agent_profiles_cli.command(
+    name="disable",
+    help="Disable a custom agent profile so it can no longer be selected at deploy time",
+)
+@synchronizer.create_blocking
+@requires_login
+async def disable_profile(
+    name: str = typer.Argument(help="Profile name to disable"),
+    organization: str = typer.Option(
+        None, "--organization", "-o", help="Organization the profile belongs to"
+    ),
+):
+    org = organization or config.get("org")
+
+    with console.status(f"[dim]Disabling agent profile '{name}'...[/dim]", spinner="dots"):
+        data, error = await API.agent_profiles_update(api_name=name, org=org, enabled=False)
+
+    if error:
+        return typer.Exit(1)
+
+    console.success(
+        f"Disabled agent profile '{name}'. Agents already deployed with it keep "
+        "running; it can no longer be selected for new deploys."
+    )

--- a/src/pipecatcloud/cli/commands/agent_profiles.py
+++ b/src/pipecatcloud/cli/commands/agent_profiles.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import re
+
 import typer
 from rich.table import Table
 
@@ -14,8 +16,10 @@ from pipecatcloud._utils.deploy_utils import ResourcesConfig
 from pipecatcloud.cli.api import API
 from pipecatcloud.cli.config import config
 
+# Registered under the agent command group, so these surface as
+# `pipecat cloud agent profiles <list|create|update|enable|disable>`.
 agent_profiles_cli = typer.Typer(
-    name="agent-profiles",
+    name="profiles",
     help=(
         "Agent profile management. The platform catalog is read-only; "
         "organizations with enterprise (self-hosted) regions can define their "
@@ -23,6 +27,20 @@ agent_profiles_cli = typer.Typer(
     ),
     no_args_is_help=True,
 )
+
+# Mirrors the server-side name rule so a typo fails before the network call:
+# lowercase alphanumerics and hyphens, must start/end alphanumeric.
+API_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+
+
+def _validate_name(name: str) -> bool:
+    if not API_NAME_PATTERN.match(name):
+        console.error(
+            f"Invalid profile name '{name}'. Use lowercase letters, digits, and "
+            "hyphens; must start and end with a letter or digit (max 63 chars)."
+        )
+        return False
+    return True
 
 
 def _validate_sizing(cpu: str, memory: str) -> bool:
@@ -49,7 +67,7 @@ async def list_profiles(
         data, error = await API.agent_profiles_list(org=org)
 
     if error:
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     profiles = (data or {}).get("agentProfiles", [])
     if not profiles:
@@ -97,8 +115,10 @@ async def create_profile(
 ):
     org = organization or config.get("org")
 
+    if not _validate_name(name):
+        raise typer.Exit(1)
     if not _validate_sizing(cpu, memory):
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     with console.status(f"[dim]Creating agent profile '{name}'...[/dim]", spinner="dots"):
         data, error = await API.agent_profiles_create(
@@ -110,7 +130,7 @@ async def create_profile(
         )
 
     if error:
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     console.success(
         f"Created agent profile '{name}' (cpu={cpu}, memory={memory}). "
@@ -137,12 +157,12 @@ async def update_profile(
 
     if (cpu is None) != (memory is None):
         console.error("--cpu and --memory must be provided together")
-        return typer.Exit(1)
+        raise typer.Exit(1)
     if cpu is None and display_name is None:
         console.error("Nothing to update. Provide --cpu/--memory and/or --display-name.")
-        return typer.Exit(1)
+        raise typer.Exit(1)
     if cpu is not None and not _validate_sizing(cpu, memory):
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     with console.status(f"[dim]Updating agent profile '{name}'...[/dim]", spinner="dots"):
         data, error = await API.agent_profiles_update(
@@ -154,7 +174,7 @@ async def update_profile(
         )
 
     if error:
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     console.success(
         f"Updated agent profile '{name}'. Running agents keep their current "
@@ -180,9 +200,33 @@ async def disable_profile(
         data, error = await API.agent_profiles_update(api_name=name, org=org, enabled=False)
 
     if error:
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     console.success(
         f"Disabled agent profile '{name}'. Agents already deployed with it keep "
-        "running; it can no longer be selected for new deploys."
+        "running; it can no longer be selected for new deploys. Re-enable it "
+        f"with: agent profiles enable {name}"
     )
+
+
+@agent_profiles_cli.command(
+    name="enable",
+    help="Re-enable a previously disabled custom agent profile",
+)
+@synchronizer.create_blocking
+@requires_login
+async def enable_profile(
+    name: str = typer.Argument(help="Profile name to re-enable"),
+    organization: str = typer.Option(
+        None, "--organization", "-o", help="Organization the profile belongs to"
+    ),
+):
+    org = organization or config.get("org")
+
+    with console.status(f"[dim]Enabling agent profile '{name}'...[/dim]", spinner="dots"):
+        data, error = await API.agent_profiles_update(api_name=name, org=org, enabled=True)
+
+    if error:
+        raise typer.Exit(1)
+
+    console.success(f"Enabled agent profile '{name}'. It can be selected for deploys again.")

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -32,6 +32,7 @@ from pipecatcloud._utils.deploy_utils import (
     KrispVivaConfig,
     ScalingParams,
     interpret_deployment_status,
+    parse_resources_option,
     with_deploy_config,
 )
 from pipecatcloud._utils.regions import get_region_codes, validate_region
@@ -612,6 +613,16 @@ def create_deploy_command(app: typer.Typer):
             help="Agent profile to use for deployment",
             rich_help_panel="Deployment Configuration",
         ),
+        resources: str = typer.Option(
+            None,
+            "--resources",
+            help=(
+                "Explicit sizing for enterprise (self-hosted) regions, as "
+                "cpu=<quantity>,memory=<quantity> (e.g. cpu=2,memory=4Gi). "
+                "Mutually exclusive with --profile."
+            ),
+            rich_help_panel="Deployment Configuration",
+        ),
         region: Region | None = typer.Option(
             None,
             "--region",
@@ -692,6 +703,25 @@ def create_deploy_command(app: typer.Typer):
             max_agents=max_agents if max_agents is not None else partial_config.scaling.max_agents,
         )
         partial_config.agent_profile = profile or partial_config.agent_profile
+        if resources is not None:
+            parsed_resources = parse_resources_option(resources)
+            if parsed_resources is None:
+                console.error(
+                    "Invalid --resources value. Expected cpu=<quantity>,memory=<quantity> "
+                    "e.g. --resources cpu=2,memory=4Gi"
+                )
+                return typer.Exit(1)
+            partial_config.resources = parsed_resources
+            # A CLI --resources overrides a config-file profile: the two are
+            # mutually exclusive, and explicit flags win over the toml.
+            if profile is None:
+                partial_config.agent_profile = None
+        if partial_config.agent_profile is not None and partial_config.resources.is_set():
+            console.error(
+                "Cannot specify both an agent profile and explicit resources. "
+                "Use --profile or --resources, not both."
+            )
+            return typer.Exit(1)
         partial_config.force_redeploy = force
         partial_config.max_session_duration = (
             max_session_duration
@@ -832,6 +862,7 @@ def create_deploy_command(app: typer.Typer):
         content_items.extend(
             [
                 f"[bold white]Agent profile:[/bold white] {'[dim]None[/dim]' if not partial_config.agent_profile else '[green]' + partial_config.agent_profile + '[/green]'}",
+                f"[bold white]Resources:[/bold white] {'[green]cpu=' + str(partial_config.resources.cpu) + ', memory=' + str(partial_config.resources.memory) + '[/green]' if partial_config.resources.is_set() else '[dim]None[/dim]'}",
                 f"[bold white]Krisp VIVA:[/bold white] {'[dim]Disabled[/dim]' if not partial_config.krisp_viva.audio_filter else '[green]Enabled (' + partial_config.krisp_viva.audio_filter + ')[/green]'}",
             ]
         )

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -30,6 +30,7 @@ from pipecatcloud._utils.deploy_utils import (
     BuildConfig,
     DeployConfigParams,
     KrispVivaConfig,
+    ResourcesConfig,
     ScalingParams,
     interpret_deployment_status,
     parse_resources_option,
@@ -702,18 +703,19 @@ def create_deploy_command(app: typer.Typer):
             min_agents=min_agents if min_agents is not None else partial_config.scaling.min_agents,
             max_agents=max_agents if max_agents is not None else partial_config.scaling.max_agents,
         )
+        # Sizing precedence: --profile and --resources are mutually exclusive,
+        # and an explicit CLI flag beats the toml's *other* sizing source in
+        # both directions (symmetry per #187 review) — --resources clears a
+        # toml agent_profile, --profile clears a toml [resources].
         partial_config.agent_profile = profile or partial_config.agent_profile
+        if profile is not None and resources is None:
+            partial_config.resources = ResourcesConfig()
         if resources is not None:
-            parsed_resources = parse_resources_option(resources)
-            if parsed_resources is None:
-                console.error(
-                    "Invalid --resources value. Expected cpu=<quantity>,memory=<quantity> "
-                    "e.g. --resources cpu=2,memory=4Gi"
-                )
-                return typer.Exit(1)
-            partial_config.resources = parsed_resources
-            # A CLI --resources overrides a config-file profile: the two are
-            # mutually exclusive, and explicit flags win over the toml.
+            try:
+                partial_config.resources = parse_resources_option(resources)
+            except ValueError as e:
+                console.error(str(e))
+                raise typer.Exit(1)
             if profile is None:
                 partial_config.agent_profile = None
         if partial_config.agent_profile is not None and partial_config.resources.is_set():
@@ -721,7 +723,7 @@ def create_deploy_command(app: typer.Typer):
                 "Cannot specify both an agent profile and explicit resources. "
                 "Use --profile or --resources, not both."
             )
-            return typer.Exit(1)
+            raise typer.Exit(1)
         partial_config.force_redeploy = force
         partial_config.max_session_duration = (
             max_session_duration

--- a/src/pipecatcloud/cli/commands/secrets.py
+++ b/src/pipecatcloud/cli/commands/secrets.py
@@ -681,3 +681,60 @@ async def image_pull_secret(
     console.success(
         f"Image pull secret [bold green]'{name}'[/bold green] for [bold green]{host}[/bold green] {action} successfully{region_info}.",
     )
+
+
+@secrets_cli.command(
+    name="reference",
+    help="Reference an existing Kubernetes Secret in a self-hosted region (enterprise)",
+)
+@synchronizer.create_blocking
+@requires_login
+async def reference_secret(
+    name: str = typer.Argument(
+        help="Name of the Kubernetes Secret in your workloads namespace (becomes the secret set name)"
+    ),
+    region: str = typer.Option(
+        ...,
+        "--region",
+        "-r",
+        help="Self-hosted region containing the secret",
+    ),
+    organization: str = typer.Option(
+        None,
+        "--organization",
+        "-o",
+        help="Organization the region belongs to",
+    ),
+):
+    """Reference an existing Kubernetes Secret so agents can use it.
+
+    Enterprise / self-hosted regions only. The secret stays in your cluster:
+    Pipecat Cloud verifies it exists and tracks readiness, but never sees its
+    values or keys. Manage the secret's contents with your own tooling
+    (kubectl); deploy agents against it by set name as usual.
+    """
+    org = organization or config.get("org")
+
+    if region and not await validate_region(region):
+        valid_regions = await get_region_codes()
+        console.print(
+            f"[red]Error: Invalid region '{region}'. Valid regions are: {', '.join(valid_regions)}[/red]"
+        )
+        return typer.Exit(1)
+
+    with console.status(
+        f"[dim]Verifying secret [bold]'{name}'[/bold] exists in [bold]{region}[/bold][/dim]",
+        spinner="dots",
+    ):
+        data, error = await API.secrets_reference(name=name, region=region, org=org)
+
+        if error:
+            return typer.Exit(1)
+
+    set_type = (data or {}).get("type")
+    type_info = " (image pull secret)" if set_type == "imagePullSecret" else ""
+    console.success(
+        f"Secret [bold green]'{name}'[/bold green] referenced in [bold cyan]{region}[/bold cyan]{type_info}\n"
+        f"[dim]The secret stays in your cluster; deleting it there will block deploys that use it.[/dim]\n"
+        f"[dim]Deploy your agent with {PIPECAT_CLI_NAME} deploy agent-name --secrets {name}[/dim]"
+    )

--- a/src/pipecatcloud/cli/commands/secrets.py
+++ b/src/pipecatcloud/cli/commands/secrets.py
@@ -720,7 +720,7 @@ async def reference_secret(
         console.print(
             f"[red]Error: Invalid region '{region}'. Valid regions are: {', '.join(valid_regions)}[/red]"
         )
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     with console.status(
         f"[dim]Verifying secret [bold]'{name}'[/bold] exists in [bold]{region}[/bold][/dim]",
@@ -729,7 +729,7 @@ async def reference_secret(
         data, error = await API.secrets_reference(name=name, region=region, org=org)
 
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     set_type = (data or {}).get("type")
     type_info = " (image pull secret)" if set_type == "imagePullSecret" else ""

--- a/src/pipecatcloud/cli/entry_point.py
+++ b/src/pipecatcloud/cli/entry_point.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from pipecatcloud._utils.console_utils import OutputMode, console
 from pipecatcloud.cli.commands.agent import agent_cli
+from pipecatcloud.cli.commands.agent_profiles import agent_profiles_cli
 from pipecatcloud.cli.commands.auth import auth_cli
 from pipecatcloud.cli.commands.build import build_cli
 from pipecatcloud.cli.commands.deploy import create_deploy_command
@@ -119,3 +120,4 @@ entrypoint_cli_typer.add_typer(regions_cli, rich_help_panel="Commands")
 entrypoint_cli_typer.add_typer(secrets_cli, rich_help_panel="Commands")
 entrypoint_cli_typer.add_typer(spend_limit_cli, rich_help_panel="Commands")
 entrypoint_cli_typer.add_typer(agent_cli, rich_help_panel="Commands")
+entrypoint_cli_typer.add_typer(agent_profiles_cli, rich_help_panel="Commands")

--- a/src/pipecatcloud/cli/entry_point.py
+++ b/src/pipecatcloud/cli/entry_point.py
@@ -119,5 +119,8 @@ entrypoint_cli_typer.add_typer(organization_cli, rich_help_panel="Commands")
 entrypoint_cli_typer.add_typer(regions_cli, rich_help_panel="Commands")
 entrypoint_cli_typer.add_typer(secrets_cli, rich_help_panel="Commands")
 entrypoint_cli_typer.add_typer(spend_limit_cli, rich_help_panel="Commands")
+# Profiles nest under agent — `pipecat cloud agent profiles <cmd>` — matching
+# how the feature is spoken about (settled in #187 review before customers
+# could script the flat form).
+agent_cli.add_typer(agent_profiles_cli)
 entrypoint_cli_typer.add_typer(agent_cli, rich_help_panel="Commands")
-entrypoint_cli_typer.add_typer(agent_profiles_cli, rich_help_panel="Commands")

--- a/src/pipecatcloud/config.py
+++ b/src/pipecatcloud/config.py
@@ -37,6 +37,7 @@ _SETTINGS = {
     "api_keys_path": _Setting("/v1/organizations/{org}/apiKeys"),
     "secrets_path": _Setting("/v1/organizations/{org}/secrets"),
     "regions_path": _Setting("/v1/organizations/{org}/regions"),
+    "agent_profiles_path": _Setting("/v1/organizations/{org}/agent-profiles"),
     "properties_path": _Setting("/v1/organizations/{org}/properties"),
     "spend_limit_path": _Setting("/v1/organizations/{org}/spend-limit"),
     "builds_path": _Setting("/v1/organizations/{org}/builds"),

--- a/tests/test_agent_profiles_and_resources.py
+++ b/tests/test_agent_profiles_and_resources.py
@@ -1,0 +1,280 @@
+"""
+Unit tests for enterprise sizing (PCC-1063): the --resources deploy flag,
+the [resources] pcc-deploy.toml section, and the agent-profiles API methods.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Import from source, not installed package
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from pipecatcloud._utils.deploy_utils import (
+    DeployConfigParams,
+    ResourcesConfig,
+    load_deploy_config_file,
+    parse_resources_option,
+)
+from pipecatcloud.api import _API
+from pipecatcloud.exception import ConfigFileError
+
+
+class TestResourcesConfig:
+    """ResourcesConfig validates k8s quantities and pairing."""
+
+    def test_default_is_unset(self):
+        config = ResourcesConfig()
+        assert not config.is_set()
+
+    @pytest.mark.parametrize(
+        "cpu,memory",
+        [("2", "4Gi"), ("500m", "1Gi"), ("1.5", "512Mi"), ("4", "8G")],
+    )
+    def test_accepts_valid_quantities(self, cpu, memory):
+        config = ResourcesConfig(cpu=cpu, memory=memory)
+        assert config.is_set()
+        assert config.to_dict() == {"cpu": cpu, "memory": memory}
+
+    @pytest.mark.parametrize(
+        "cpu,memory",
+        [("two", "4Gi"), ("2", "lots"), ("-1", "4Gi"), ("2", "4GiB"), ("", "4Gi")],
+    )
+    def test_rejects_invalid_quantities(self, cpu, memory):
+        with pytest.raises(ValueError, match="quantity"):
+            ResourcesConfig(cpu=cpu, memory=memory)
+
+    def test_rejects_partial_pair(self):
+        with pytest.raises(ValueError, match="both"):
+            ResourcesConfig(cpu="2")
+        with pytest.raises(ValueError, match="both"):
+            ResourcesConfig(memory="4Gi")
+
+
+class TestParseResourcesOption:
+    """--resources cpu=X,memory=Y parsing."""
+
+    def test_parses_valid_value(self):
+        parsed = parse_resources_option("cpu=2,memory=4Gi")
+        assert parsed is not None
+        assert parsed.to_dict() == {"cpu": "2", "memory": "4Gi"}
+
+    def test_order_does_not_matter_and_spaces_tolerated(self):
+        parsed = parse_resources_option("memory=4Gi, cpu=500m")
+        assert parsed is not None
+        assert parsed.to_dict() == {"cpu": "500m", "memory": "4Gi"}
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "cpu=2",  # missing memory
+            "memory=4Gi",  # missing cpu
+            "cpu=2,memory=4Gi,gpu=1",  # unknown key
+            "cpu=,memory=4Gi",  # empty value
+            "2,4Gi",  # no keys
+            "cpu=two,memory=4Gi",  # bad quantity
+            "",
+        ],
+    )
+    def test_rejects_malformed_values(self, value):
+        assert parse_resources_option(value) is None
+
+
+class TestDeployConfigMutualExclusion:
+    """agent_profile and resources are mutually exclusive."""
+
+    def test_profile_alone_ok(self):
+        config = DeployConfigParams(agent_profile="agent-1x")
+        assert config.agent_profile == "agent-1x"
+
+    def test_resources_alone_ok(self):
+        config = DeployConfigParams(resources=ResourcesConfig(cpu="2", memory="4Gi"))
+        assert config.resources.is_set()
+
+    def test_both_rejected(self):
+        with pytest.raises(ValueError, match="agent_profile.*resources"):
+            DeployConfigParams(
+                agent_profile="agent-1x",
+                resources=ResourcesConfig(cpu="2", memory="4Gi"),
+            )
+
+    def test_round_trips_through_to_dict(self):
+        config = DeployConfigParams(resources=ResourcesConfig(cpu="2", memory="4Gi"))
+        assert config.to_dict()["resources"] == {"cpu": "2", "memory": "4Gi"}
+
+    def test_to_dict_omits_unset_resources(self):
+        config = DeployConfigParams(agent_name="a")
+        assert config.to_dict()["resources"] is None
+
+
+class TestTOMLConfiguration:
+    """[resources] can be loaded from pcc-deploy.toml."""
+
+    @pytest.fixture
+    def temp_config_file(self, tmp_path):
+        return tmp_path / "pcc-deploy.toml"
+
+    def test_loads_resources_section(self, temp_config_file):
+        temp_config_file.write_text(
+            """
+agent_name = "my-agent"
+image = "test:latest"
+
+[resources]
+cpu = "2"
+memory = "4Gi"
+"""
+        )
+        with patch("pipecatcloud.cli.config.deploy_config_path", str(temp_config_file)):
+            config = load_deploy_config_file()
+
+        assert config is not None
+        assert config.resources.is_set()
+        assert config.resources.to_dict() == {"cpu": "2", "memory": "4Gi"}
+
+    def test_absent_section_is_unset(self, temp_config_file):
+        temp_config_file.write_text(
+            """
+agent_name = "my-agent"
+image = "test:latest"
+"""
+        )
+        with patch("pipecatcloud.cli.config.deploy_config_path", str(temp_config_file)):
+            config = load_deploy_config_file()
+
+        assert config is not None
+        assert not config.resources.is_set()
+
+    def test_profile_and_resources_together_is_config_error(self, temp_config_file):
+        temp_config_file.write_text(
+            """
+agent_name = "my-agent"
+image = "test:latest"
+agent_profile = "agent-1x"
+
+[resources]
+cpu = "2"
+memory = "4Gi"
+"""
+        )
+        with patch("pipecatcloud.cli.config.deploy_config_path", str(temp_config_file)):
+            with pytest.raises(ConfigFileError, match="agent_profile.*resources"):
+                load_deploy_config_file()
+
+    def test_bad_quantity_is_config_error(self, temp_config_file):
+        temp_config_file.write_text(
+            """
+agent_name = "my-agent"
+image = "test:latest"
+
+[resources]
+cpu = "two"
+memory = "4Gi"
+"""
+        )
+        with patch("pipecatcloud.cli.config.deploy_config_path", str(temp_config_file)):
+            with pytest.raises(ConfigFileError, match="quantity"):
+                load_deploy_config_file()
+
+
+class TestDeployPayload:
+    """API client sends resources in the deploy payload."""
+
+    @pytest.fixture
+    def api_client(self):
+        return _API(token="test-token", is_cli=True)
+
+    @pytest.mark.asyncio
+    async def test_payload_includes_resources(self, api_client):
+        config = DeployConfigParams(
+            agent_name="test-agent",
+            image="test:latest",
+            resources=ResourcesConfig(cpu="2", memory="4Gi"),
+        )
+
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"success": True}
+            await api_client._deploy(config, "test-org", update=False)
+
+            payload = mock_request.call_args[1]["json"]
+            assert payload["resources"] == {"cpu": "2", "memory": "4Gi"}
+            assert "agentProfile" not in payload
+
+    @pytest.mark.asyncio
+    async def test_payload_omits_resources_when_unset(self, api_client):
+        config = DeployConfigParams(
+            agent_name="test-agent", image="test:latest", agent_profile="agent-1x"
+        )
+
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"success": True}
+            await api_client._deploy(config, "test-org", update=False)
+
+            payload = mock_request.call_args[1]["json"]
+            assert "resources" not in payload
+            assert payload["agentProfile"] == "agent-1x"
+
+
+class TestAgentProfilesAPI:
+    """Agent-profile CRUD methods hit the org-scoped routes."""
+
+    @pytest.fixture
+    def api_client(self):
+        return _API(token="test-token", is_cli=True)
+
+    @pytest.mark.asyncio
+    async def test_list(self, api_client):
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"agentProfiles": []}
+            result = await api_client._agent_profiles_list("my-org")
+
+            method, url = mock_request.call_args[0][:2]
+            assert method == "GET"
+            assert url.endswith("/v1/organizations/my-org/agent-profiles")
+            assert result == {"agentProfiles": []}
+
+    @pytest.mark.asyncio
+    async def test_create(self, api_client):
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"api_name": "telephony-large"}
+            await api_client._agent_profiles_create(
+                api_name="telephony-large",
+                display_name="Telephony Large",
+                cpu="2",
+                memory="4Gi",
+                org="my-org",
+            )
+
+            method, url = mock_request.call_args[0][:2]
+            assert method == "POST"
+            assert url.endswith("/v1/organizations/my-org/agent-profiles")
+            assert mock_request.call_args[1]["json"] == {
+                "apiName": "telephony-large",
+                "displayName": "Telephony Large",
+                "resources": {"cpu": "2", "memory": "4Gi"},
+            }
+
+    @pytest.mark.asyncio
+    async def test_update_sizing(self, api_client):
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {}
+            await api_client._agent_profiles_update(
+                api_name="telephony-large", org="my-org", cpu="4", memory="8Gi"
+            )
+
+            method, url = mock_request.call_args[0][:2]
+            assert method == "PATCH"
+            assert url.endswith("/v1/organizations/my-org/agent-profiles/telephony-large")
+            assert mock_request.call_args[1]["json"] == {"resources": {"cpu": "4", "memory": "8Gi"}}
+
+    @pytest.mark.asyncio
+    async def test_disable(self, api_client):
+        with patch.object(api_client, "_base_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {}
+            await api_client._agent_profiles_update(
+                api_name="telephony-large", org="my-org", enabled=False
+            )
+
+            assert mock_request.call_args[1]["json"] == {"enabled": False}

--- a/tests/test_agent_profiles_and_resources.py
+++ b/tests/test_agent_profiles_and_resources.py
@@ -58,28 +58,29 @@ class TestParseResourcesOption:
 
     def test_parses_valid_value(self):
         parsed = parse_resources_option("cpu=2,memory=4Gi")
-        assert parsed is not None
         assert parsed.to_dict() == {"cpu": "2", "memory": "4Gi"}
 
     def test_order_does_not_matter_and_spaces_tolerated(self):
         parsed = parse_resources_option("memory=4Gi, cpu=500m")
-        assert parsed is not None
         assert parsed.to_dict() == {"cpu": "500m", "memory": "4Gi"}
 
     @pytest.mark.parametrize(
-        "value",
+        "value,match",
         [
-            "cpu=2",  # missing memory
-            "memory=4Gi",  # missing cpu
-            "cpu=2,memory=4Gi,gpu=1",  # unknown key
-            "cpu=,memory=4Gi",  # empty value
-            "2,4Gi",  # no keys
-            "cpu=two,memory=4Gi",  # bad quantity
-            "",
+            ("cpu=2", "requires exactly"),  # missing memory
+            ("memory=4Gi", "requires exactly"),  # missing cpu
+            ("cpu=2,memory=4Gi,gpu=1", "requires exactly"),  # unknown key
+            ("cpu=,memory=4Gi", "Malformed"),  # empty value
+            ("2,4Gi", "Malformed"),  # no keys
+            ("cpu=two,memory=4Gi", "quantity"),  # bad quantity, specific message
+            ("", "Malformed"),
         ],
     )
-    def test_rejects_malformed_values(self, value):
-        assert parse_resources_option(value) is None
+    def test_rejects_malformed_values_with_specific_errors(self, value, match):
+        # #187 review: the specific reason must survive to the caller — the
+        # deploy command prints str(e), not a generic usage error.
+        with pytest.raises(ValueError, match=match):
+            parse_resources_option(value)
 
 
 class TestDeployConfigMutualExclusion:

--- a/tests/test_secrets_reference.py
+++ b/tests/test_secrets_reference.py
@@ -31,7 +31,10 @@ def reference_mocks():
         ),
     ):
         mock_api.secrets_reference = AsyncMock(
-            return_value=({"name": "bot-keys", "region": "onprem-a", "type": "secret", "status": "ready"}, None)
+            return_value=(
+                {"name": "bot-keys", "region": "onprem-a", "type": "secret", "status": "ready"},
+                None,
+            )
         )
         yield mock_api
 

--- a/tests/test_secrets_reference.py
+++ b/tests/test_secrets_reference.py
@@ -53,10 +53,10 @@ async def test_reference_api_error_exits_nonzero(reference_mocks):
     """Server-side rejections (secret missing, cloud region, unreachable) exit 1."""
     reference_mocks.secrets_reference = AsyncMock(return_value=(None, {"code": "400"}))
 
-    result = await reference_secret.aio(name="nope", region="onprem-a", organization="acme")
+    with pytest.raises(typer.Exit) as excinfo:
+        await reference_secret.aio(name="nope", region="onprem-a", organization="acme")
 
-    assert isinstance(result, typer.Exit)
-    assert result.exit_code == 1
+    assert excinfo.value.exit_code == 1
 
 
 @pytest.mark.asyncio
@@ -76,10 +76,10 @@ async def test_invalid_region_rejected_client_side():
     ):
         mock_api.secrets_reference = AsyncMock()
 
-        result = await reference_secret.aio(name="bot-keys", region="bogus", organization="acme")
+        with pytest.raises(typer.Exit) as excinfo:
+            await reference_secret.aio(name="bot-keys", region="bogus", organization="acme")
 
-        assert isinstance(result, typer.Exit)
-        assert result.exit_code == 1
+        assert excinfo.value.exit_code == 1
         mock_api.secrets_reference.assert_not_awaited()
 
 

--- a/tests/test_secrets_reference.py
+++ b/tests/test_secrets_reference.py
@@ -1,0 +1,88 @@
+"""
+Tests for `secrets reference` (PCC-1021): referencing an existing Kubernetes
+Secret in a self-hosted (enterprise) region.
+
+Backward compatibility is the load-bearing property: this is a net-new
+subcommand, so these tests also pin that the existing secrets commands are
+untouched (the command registry still exposes them unchanged).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import typer
+
+# Import from source, not installed package
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from pipecatcloud.cli.commands.secrets import reference_secret, secrets_cli
+
+
+@pytest.fixture
+def reference_mocks():
+    with (
+        patch("pipecatcloud.cli.commands.secrets.API") as mock_api,
+        patch("pipecatcloud.cli.commands.secrets.console"),
+        patch(
+            "pipecatcloud.cli.commands.secrets.validate_region",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        mock_api.secrets_reference = AsyncMock(
+            return_value=({"name": "bot-keys", "region": "onprem-a", "type": "secret", "status": "ready"}, None)
+        )
+        yield mock_api
+
+
+@pytest.mark.asyncio
+async def test_reference_calls_api_with_name_region_org(reference_mocks):
+    await reference_secret.aio(name="bot-keys", region="onprem-a", organization="acme")
+
+    reference_mocks.secrets_reference.assert_awaited_once_with(
+        name="bot-keys", region="onprem-a", org="acme"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reference_api_error_exits_nonzero(reference_mocks):
+    """Server-side rejections (secret missing, cloud region, unreachable) exit 1."""
+    reference_mocks.secrets_reference = AsyncMock(return_value=(None, {"code": "400"}))
+
+    result = await reference_secret.aio(name="nope", region="onprem-a", organization="acme")
+
+    assert isinstance(result, typer.Exit)
+    assert result.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_region_rejected_client_side():
+    """A region the org can't use fails before any API call."""
+    with (
+        patch("pipecatcloud.cli.commands.secrets.API") as mock_api,
+        patch("pipecatcloud.cli.commands.secrets.console"),
+        patch(
+            "pipecatcloud.cli.commands.secrets.validate_region",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "pipecatcloud.cli.commands.secrets.get_region_codes",
+            new=AsyncMock(return_value=["us-west"]),
+        ),
+    ):
+        mock_api.secrets_reference = AsyncMock()
+
+        result = await reference_secret.aio(name="bot-keys", region="bogus", organization="acme")
+
+        assert isinstance(result, typer.Exit)
+        assert result.exit_code == 1
+        mock_api.secrets_reference.assert_not_awaited()
+
+
+def test_existing_commands_are_untouched():
+    """Backward compatibility: the pre-existing command surface is unchanged and
+    `reference` is purely additive."""
+    names = {cmd.name for cmd in secrets_cli.registered_commands}
+    assert {"set", "unset", "list", "delete"}.issubset(names)
+    assert "reference" in names


### PR DESCRIPTION
**On-prem/enterprise work (PCC-957) — no rush to release.** Part of referenced-secrets phase 1 (design: [region-package docs/secrets.md](https://github.com/daily-co/pipecat-cloud-region-package/blob/main/docs/secrets.md)).

## Dependencies

Server-side API surface: sandbox [#695](https://github.com/daily-co/pipecat-cloud-sandbox/pull/695) + [#696](https://github.com/daily-co/pipecat-cloud-sandbox/pull/696) (`POST /secrets/references`). **This PR does not need to wait for them**: see backward compatibility below.

## Backward compatibility — safe to release any time

- `secrets reference` is a **net-new subcommand**; existing `set`/`unset`/`list`/`delete` are untouched (pinned by a registry test).
- If released before the server API is live (or invoked by an org with no self-hosted regions), the command simply surfaces the server's error and exits 1 — no other CLI surface changes.
- `secrets list` already renders unfamiliar statuses tolerantly (`_format_status` passes unknown values through dimmed), so the new `unknown` readiness state needs no change here.
- Region validation is dynamic (fetched per-org from the API), so self-hosted region keys work with zero client changes.

## What

- `pipecat cloud secrets reference NAME --region REGION` — verifies the secret exists in the region and registers the reference; success output notes the secret stays in the customer's cluster and that deleting it there blocks deploys.
- `_API.secrets_reference` → `POST /secrets/references {name, region}`.
- Tests: API call shape, server-error exit, client-side region rejection (no API call), and the backward-compat registry pin.

Pre-existing, untouched: `test_spend_limit::test_show_json_prints_payload` fails identically on main.