### PR TITLE
PCC-1064: non-interactive output modes, real exit codes, machine-readable JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   back to an 80-column table that silently ellipsized IDs.
 
 - `agent status` and `agent deployments` now show `Build: <build id>` for
-  cloud-built deployments instead of `Image: N/A` (the internal image URI is
-  redacted by the API; the build ID is the customer-facing reference).
+  cloud-built deployments instead of `Image: N/A`. Cloud builds produce an
+  image managed by Pipecat Cloud, so the build ID is the reference to use
+  when checking which artifact a deployment is running.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New global `--output {rich,plain,json}` option for every `pipecat cloud`
+  command, also settable via the `PIPECAT_OUTPUT` environment variable or the
+  `output` config key. `rich` is the interactive default; `plain` is
+  line-oriented with no boxes and no truncation; `json` emits one
+  machine-readable JSON object on stdout with all human output on stderr.
+  When stdout is not a terminal the CLI now defaults to `plain`.
+
+- Progress is now visible when output is piped or redirected. Long-running
+  operations (deploy rollout polling, cloud builds) print each status
+  transition as a timestamped line instead of rendering nothing outside a
+  terminal. Cloud-build polling additionally reports build status changes.
+
+- Listings (`agent list`, `agent sessions`, `agent deployments`,
+  `secrets list`, `organizations list`, `organizations keys list`, `build
+  list`, `regions list`, and friends) render as tab-separated rows with
+  full, untruncated values in `plain` mode. Piped output previously fell
+  back to an 80-column table that silently ellipsized IDs.
+
+- `agent status` and `agent deployments` now show `Build: <build id>` for
+  cloud-built deployments instead of `Image: N/A` (the internal image URI is
+  redacted by the API; the build ID is the customer-facing reference).
+
+### Changed
+
+- **The CLI now exits non-zero on failure.** Previously every error path
+  exited `0` — including failed deploys and running commands while logged
+  out — so CI pipelines could not detect failures. Errors and user
+  cancellations exit `1`; usage errors and refused non-interactive prompts
+  exit `2`. Pipelines that depended on the old always-zero behavior will
+  now correctly fail.
+
+- Commands that would show a confirmation prompt now fail fast with exit
+  code `2` when stdin is not a terminal, pointing at the bypass flag
+  (`--yes`/`--force`/`--skip`), instead of hanging or misbehaving in CI.
+
+### Deprecated
+
+- `spend-limit show --json` still works but is now an alias for the global
+  `--output json` mode.
+
 ## [1.0.1] - 2026-07-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New global `--output {rich,plain,json}` option for every `pipecat cloud`
   command, also settable via the `PIPECAT_OUTPUT` environment variable or the
-  `output` config key. `rich` is the interactive default; `plain` is
+  `output` config key. Note the option is placed before the subcommand
+  (`pipecat cloud --output json agent list`); in CI, setting `PIPECAT_OUTPUT`
+  once avoids ordering concerns. `rich` is the interactive default; `plain` is
   line-oriented with no boxes and no truncation; `json` emits one
   machine-readable JSON object on stdout with all human output on stderr.
   When stdout is not a terminal the CLI now defaults to `plain`.

--- a/src/pipecatcloud/_utils/auth_utils.py
+++ b/src/pipecatcloud/_utils/auth_utils.py
@@ -7,6 +7,7 @@
 import functools
 
 import aiohttp
+import typer
 
 from pipecatcloud.__version__ import version
 from pipecatcloud._utils.console_utils import console
@@ -46,7 +47,7 @@ def requires_login(func):
             console.error(
                 f"You are not logged in. Please run `{PIPECAT_CLI_NAME} auth login` first.",
             )
-            return
+            raise typer.Exit(1)
 
         # When org is not set locally (e.g. PIPECAT_TOKEN without a config file),
         # resolve the user's default organization from the API.
@@ -59,7 +60,7 @@ def requires_login(func):
                     "Could not determine your organization. "
                     f"Set PIPECAT_ORG or run `{PIPECAT_CLI_NAME} auth login`.",
                 )
-                return
+                raise typer.Exit(1)
 
         return await func(*args, **kwargs)
 

--- a/src/pipecatcloud/_utils/console_utils.py
+++ b/src/pipecatcloud/_utils/console_utils.py
@@ -5,12 +5,73 @@
 #
 
 import statistics
+import sys
 from datetime import datetime
+from enum import Enum
 
 from rich.console import Console
 from rich.panel import Panel
 
 from pipecatcloud.cli import PANEL_TITLE_ERROR, PANEL_TITLE_SUCCESS, PIPECAT_CLI_NAME
+
+
+class OutputMode(str, Enum):
+    """How the CLI renders its output.
+
+    - ``rich``: panels, spinners, and tables (the interactive default)
+    - ``plain``: line-oriented output — no boxes, no spinners, no truncation
+    - ``json``: one machine-parseable JSON object on stdout; all human
+      output is redirected to stderr
+    """
+
+    rich = "rich"
+    plain = "plain"
+    json = "json"
+
+
+def stdin_is_interactive() -> bool:
+    """Whether we can prompt the user. Separate function so tests can patch it."""
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+class _PlainStatus:
+    """Drop-in replacement for rich's Status in non-interactive output.
+
+    Rich renders nothing from ``console.status(...)`` when stdout is not a
+    terminal, which left long-running operations (e.g. the up-to-600s deploy
+    poll loop) completely silent in CI. This sink prints each *distinct*
+    status message as a timestamped line instead, so piped output shows
+    every transition without spamming identical poll updates.
+    """
+
+    def __init__(self, console: "PipecatConsole", message: str | None = None):
+        self._console = console
+        self._last: str | None = None
+        self._stopped = False
+        if message:
+            self.update(message)
+
+    def update(self, status: str | None = None, **kwargs) -> None:
+        if not status or self._stopped or status == self._last:
+            return
+        self._last = status
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        self._console.print(rf"[dim]\[{timestamp}][/dim] {status}")
+
+    def start(self) -> None:
+        self._stopped = False
+
+    def stop(self) -> None:
+        self._stopped = True
+
+    def __enter__(self) -> "_PlainStatus":
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self.stop()
 
 
 def format_cents(cents: int | None) -> str:
@@ -28,6 +89,79 @@ def format_cents(cents: int | None) -> str:
 
 
 class PipecatConsole(Console):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # None means "auto": rich on a terminal, plain otherwise.
+        self._explicit_output_mode: OutputMode | None = None
+
+    @property
+    def output_mode(self) -> OutputMode:
+        if self._explicit_output_mode is not None:
+            return self._explicit_output_mode
+        return OutputMode.rich if self.is_terminal else OutputMode.plain
+
+    def set_output_mode(self, mode: OutputMode) -> None:
+        self._explicit_output_mode = mode
+        if mode == OutputMode.json:
+            # stdout is reserved for the single JSON payload; every human-facing
+            # write on this console moves to stderr so parsers see pure JSON.
+            self.file = sys.stderr
+
+    @property
+    def rich_output(self) -> bool:
+        return self.output_mode == OutputMode.rich
+
+    def status(self, status, **kwargs):  # pyright: ignore[reportIncompatibleMethodOverride]
+        # Returns rich's Status in rich mode and a line-printing _PlainStatus
+        # otherwise; both expose update()/stop()/context-manager.
+        if self.rich_output:
+            return super().status(status, **kwargs)
+        return _PlainStatus(self, str(status))
+
+    def require_interactive(self, flag_hint: str | None = "--yes") -> None:
+        """Fail fast instead of letting a prompt hang or misbehave in CI.
+
+        Exits 2 (usage error) when a prompt would be shown but stdin is not a
+        terminal, pointing at the flag that skips the prompt when one exists.
+        """
+        import typer
+
+        if not stdin_is_interactive():
+            remedy = (
+                f"Pass [bold]{flag_hint}[/bold] to run non-interactively."
+                if flag_hint
+                else "This command requires an interactive terminal."
+            )
+            self.error(f"Confirmation required but input is not a terminal.\n{remedy}")
+            raise typer.Exit(2)
+
+    def print(self, *objects, **kwargs):
+        # In non-rich modes, never hard-wrap plain text lines: wrapped IDs and
+        # URIs are as unparseable as truncated ones.
+        if not self.rich_output and objects and all(isinstance(o, str) for o in objects):
+            kwargs.setdefault("soft_wrap", True)
+        return super().print(*objects, **kwargs)
+
+    def print_records(
+        self,
+        columns: list[str],
+        rows: list[tuple],
+        title: str | None = None,
+    ) -> None:
+        """Plain-mode listing: tab-separated, full values, no boxes.
+
+        Rich tables ellipsize cell values at 80 columns when piped, which
+        silently corrupts IDs consumed by scripts. Rows are written straight to
+        the output stream — bypassing Rich's tab expansion and line wrapping —
+        so the output stays greppable and `cut`-able.
+        """
+        if title:
+            self.print(title)
+        self.file.write("\t".join(columns) + "\n")
+        for row in rows:
+            self.file.write("\t".join("" if cell is None else str(cell) for cell in row) + "\n")
+        self.file.flush()
+
     def success(
         self,
         message,
@@ -37,6 +171,16 @@ class PipecatConsole(Console):
     ):
         if not title:
             title = f"{PANEL_TITLE_SUCCESS}{f' - {title_extra}' if title_extra is not None else ''}"
+
+        if not self.rich_output:
+            if isinstance(message, str):
+                self.print(f"[bold green]{title}:[/bold green] {message}")
+            else:
+                self.print(f"[bold green]{title}[/bold green]")
+                self.print(message)
+            if subtitle:
+                self.print(subtitle)
+            return
 
         self.print(
             Panel(
@@ -59,6 +203,16 @@ class PipecatConsole(Console):
         if not title:
             title = f"{PANEL_TITLE_ERROR}{f' - {title_extra}' if title_extra is not None else ''}"
 
+        if not self.rich_output:
+            if isinstance(message, str):
+                self.print(f"[bold red]{title}:[/bold red] {message}")
+            else:
+                self.print(f"[bold red]{title}[/bold red]")
+                self.print(message)
+            if subtitle:
+                self.print(subtitle)
+            return
+
         self.print(
             Panel(
                 message,
@@ -74,9 +228,16 @@ class PipecatConsole(Console):
         self.print("[yellow]Cancelled by user[/yellow]")
 
     def unauthorized(self):
+        message = (
+            "Unauthorized request / invalid user token.\n\n"
+            f"Please log in again using [bold cyan]{PIPECAT_CLI_NAME} auth login[/bold cyan]"
+        )
+        if not self.rich_output:
+            self.error(message, title=f"{PANEL_TITLE_ERROR} - Unauthorized (401)")
+            return
         self.print(
             Panel(
-                f"Unauthorized request / invalid user token.\n\nPlease log in again using [bold cyan]{PIPECAT_CLI_NAME} auth login[/bold cyan]",
+                message,
                 title=f"[bold red]{PANEL_TITLE_ERROR} - Unauthorized (401)[/bold red]",
                 subtitle="",
                 title_align="left",
@@ -112,13 +273,22 @@ class PipecatConsole(Console):
         if not error_message:
             hide_subtitle = True
 
+        panel_title = f"{PANEL_TITLE_ERROR}{f' - {code}' if code else ''}"
+        subtitle = (
+            f"[dim]Docs: https://docs.pipecat.ai/pipecat-cloud/fundamentals/error-codes#{str(code).lower()}[/dim]"
+            if not hide_subtitle and code
+            else None
+        )
+
+        if not self.rich_output:
+            self.error(f"{title}: {error_message}", title=panel_title, subtitle=subtitle)
+            return
+
         self.print(
             Panel(
                 f"[red]{title}[/red]\n\n[dim]Error message:[/dim]\n{error_message}",
-                title=f"[bold red]{PANEL_TITLE_ERROR}{f' - {code}' if code else ''}[/bold red]",
-                subtitle=f"[dim]Docs: https://docs.pipecat.ai/pipecat-cloud/fundamentals/error-codes#{str(code).lower()}[/dim]"
-                if not hide_subtitle and code
-                else None,
+                title=f"[bold red]{panel_title}[/bold red]",
+                subtitle=subtitle,
                 title_align="left",
                 subtitle_align="left",
                 border_style="red",
@@ -157,6 +327,10 @@ class PipecatConsole(Console):
             f"  [bold cyan]{PIPECAT_CLI_NAME} spend-limit clear[/bold cyan]\n\n"
             f"Or visit [link={dashboard}]{dashboard}[/link]"
         )
+
+        if not self.rich_output:
+            self.error(body, title=f"{PANEL_TITLE_ERROR} - Spend limit reached (402)")
+            return
 
         self.print(
             Panel(

--- a/src/pipecatcloud/_utils/console_utils.py
+++ b/src/pipecatcloud/_utils/console_utils.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import json
 import statistics
 import sys
 from datetime import datetime
@@ -110,6 +111,19 @@ class PipecatConsole(Console):
     @property
     def rich_output(self) -> bool:
         return self.output_mode == OutputMode.rich
+
+    @property
+    def json_output(self) -> bool:
+        return self.output_mode == OutputMode.json
+
+    def output_json(self, data) -> None:
+        """Write the single machine-readable JSON object to stdout.
+
+        In json mode this console's own writes go to stderr, so this is the
+        only thing that touches stdout — parsers get pure JSON.
+        """
+        sys.stdout.write(json.dumps(data, indent=2, default=str) + "\n")
+        sys.stdout.flush()
 
     def status(self, status, **kwargs):  # pyright: ignore[reportIncompatibleMethodOverride]
         # Returns rich's Status in rich mode and a line-printing _PlainStatus

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -197,6 +197,10 @@ class _API:
 
         if not self.error:
             return
+        # In json mode the machine-readable error goes to stdout; the human
+        # rendering below lands on stderr (the console is redirected there).
+        if self.is_cli and getattr(console, "json_output", False):
+            console.output_json({"error": self.error})
         if isinstance(self.error, dict) and self.error.get("code", "400") == "401":
             console.unauthorized()
         else:

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -82,6 +82,23 @@ def format_cpu(millicores: int) -> str:
     return f"{millicores / 1000:.2f} cores"
 
 
+def _image_display(deployment: dict) -> tuple[str, str]:
+    """Label and value for the artifact a deployment runs.
+
+    Cloud-built deployments have their internal ECR image URI redacted by the
+    API (sanitizeDeploymentForResponse), which used to render as "Image: N/A".
+    The build ID is the customer-facing reference for those, so show it.
+    """
+    spec = deployment.get("manifest", {}).get("spec", {})
+    image = spec.get("image")
+    if image:
+        return "Image", str(image)
+    build_id = deployment.get("buildId")
+    if build_id:
+        return "Build", str(build_id)
+    return "Image", "N/A"
+
+
 # ----- Agent Commands -----
 
 
@@ -205,7 +222,8 @@ async def status(
             if current_rev:
                 console.print(f"Deployment Phase: {current_rev.get('phase', 'Unknown')}")
             console.print(f"Active Session Count: {data.get('activeSessionCount', 'N/A')}")
-            console.print(f"Image: {spec.get('image', 'N/A')}")
+            image_label, image_value = _image_display(data.get("deployment", {}))
+            console.print(f"{image_label}: {image_value}")
             if data.get("agentProfile"):
                 console.print(f"Agent Profile: {data['agentProfile']}")
             console.print(f"Active Deployment ID: {data.get('activeDeploymentId', 'N/A')}")
@@ -240,9 +258,10 @@ async def status(
             "[bold]Active Session Count:[/bold]",
             str(data.get("activeSessionCount", "N/A")),
         )
+        image_label, image_value = _image_display(data.get("deployment", {}))
         deployment_table.add_row(
-            "[bold]Image:[/bold]",
-            str(data.get("deployment", {}).get("manifest", {}).get("spec", {}).get("image", "N/A")),
+            f"[bold]{image_label}:[/bold]",
+            image_value,
         )
 
         # Display agent profile if available
@@ -864,14 +883,14 @@ async def deployments(
 
             if not console.rich_output:
                 console.print_records(
-                    ["ID", "Node Type", "Image", "Created At", "Updated At"],
+                    ["ID", "Node Type", "Image / Build", "Created At", "Updated At"],
                     [
                         (
                             deployment.get("id", "N/A"),
                             deployment.get("manifest", {})
                             .get("spec", {})
                             .get("dailyNodeType", "N/A"),
-                            deployment.get("manifest", {}).get("spec", {}).get("image", "N/A"),
+                            _image_display(deployment)[1],
                             deployment.get("createdAt", "N/A"),
                             deployment.get("updatedAt", "N/A"),
                         )
@@ -889,7 +908,7 @@ async def deployments(
             )
             table.add_column("ID")
             table.add_column("Node Type")
-            table.add_column("Image")
+            table.add_column("Image / Build")
             table.add_column("Created At")
             table.add_column("Updated At")
 
@@ -898,7 +917,7 @@ async def deployments(
                 table.add_row(
                     deployment.get("id", "N/A"),
                     spec.get("dailyNodeType", "N/A"),
-                    spec.get("image", "N/A"),
+                    _image_display(deployment)[1],
                     deployment.get("createdAt", "N/A"),
                     deployment.get("updatedAt", "N/A"),
                 )

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -14,7 +14,6 @@ from loguru import logger
 from rich import box
 from rich.columns import Columns
 from rich.console import Group
-from rich.live import Live
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -125,6 +124,22 @@ async def list_agents(
             )
             raise typer.Exit(1)
 
+        elif not console.rich_output:
+            console.print_records(
+                ["Name", "Region", "Agent ID", "Active Deployment ID", "Created At", "Updated At"],
+                [
+                    (
+                        service["name"],
+                        service["region"],
+                        service["id"],
+                        service["activeDeploymentId"],
+                        service["createdAt"],
+                        service["updatedAt"],
+                    )
+                    for service in data
+                ],
+                title=f"Agents for organization: {org} ({len(data)} results)",
+            )
         else:
             table = Table(show_header=True, show_lines=True, border_style="dim", box=box.SIMPLE)
             table.add_column("Name")
@@ -160,8 +175,8 @@ async def status(
 ):
     org = organization or config.get("org")
 
-    with Live(
-        console.status(f"[dim]Looking up agent with name {agent_name}[/dim]", spinner="dots")
+    with console.status(
+        f"[dim]Looking up agent with name {agent_name}[/dim]", spinner="dots"
     ) as live:
         data, error = await API.agent(agent_name=agent_name, org=org, live=live)
 
@@ -175,6 +190,40 @@ async def status(
         if not data:
             console.error(f"No deployment data found for agent with name '{agent_name}'")
             raise typer.Exit(1)
+
+        if not console.rich_output:
+            spec = data.get("deployment", {}).get("manifest", {}).get("spec", {})
+            console.print(f"Agent: {agent_name}")
+            console.print(f"Ready: {bool(data.get('ready'))}")
+            current_rev = data.get("currentRevision")
+            if current_rev:
+                console.print(f"Deployment Phase: {current_rev.get('phase', 'Unknown')}")
+            console.print(f"Active Session Count: {data.get('activeSessionCount', 'N/A')}")
+            console.print(f"Image: {spec.get('image', 'N/A')}")
+            if data.get("agentProfile"):
+                console.print(f"Agent Profile: {data['agentProfile']}")
+            console.print(f"Active Deployment ID: {data.get('activeDeploymentId', 'N/A')}")
+            console.print(f"Created At: {data.get('createdAt', 'N/A')}")
+            console.print(f"Updated At: {data.get('updatedAt', 'N/A')}")
+            krisp_viva = data.get("krispViva") or {}
+            audio_filter = krisp_viva.get("audioFilter")
+            console.print(
+                f"Krisp VIVA: {f'Enabled ({audio_filter})' if audio_filter else 'Disabled'}"
+            )
+            max_session_duration = spec.get("maxSessionDurationSeconds")
+            console.print(
+                f"Max Session Duration: "
+                f"{f'{max_session_duration}s' if max_session_duration is not None else 'default'}"
+            )
+            autoscaling = data.get("autoScaling") or {}
+            if autoscaling:
+                console.print(f"Min Agents: {autoscaling.get('minReplicas', 0)}")
+                console.print(f"Max Agents: {autoscaling.get('maxReplicas', 0)}")
+            for status_error in data.get("errors") or []:
+                code = status_error.get("code", "")
+                detail = status_error.get("message") or status_error.get("error", "Unknown error")
+                console.print(f"Error: {code} {detail}")
+            return
 
         # Deployment info
 
@@ -387,8 +436,8 @@ async def sessions(
 
     # If session_id is specified, fetch single session with detailed metrics
     if session_id:
-        with Live(
-            console.status(f"[dim]Looking up session '{session_id}'[/dim]", spinner="dots")
+        with console.status(
+            f"[dim]Looking up session '{session_id}'[/dim]", spinner="dots"
         ) as live:
             data, error = await API.agent_session(
                 agent_name=agent_name, session_id=session_id, org=org, live=live
@@ -469,8 +518,8 @@ async def sessions(
             )
             return
 
-    with Live(
-        console.status(f"[dim]Looking up agent with name '{agent_name}'[/dim]", spinner="dots")
+    with console.status(
+        f"[dim]Looking up agent with name '{agent_name}'[/dim]", spinner="dots"
     ) as live:
         data, error = await API.agent_sessions(agent_name=agent_name, org=org, live=live)
 
@@ -485,6 +534,36 @@ async def sessions(
 
         sessions_list = data.get("sessions", [])
         total_sessions = len(sessions_list)
+
+        if not console.rich_output:
+            console.print_records(
+                [
+                    "Session ID",
+                    "Created At",
+                    "Ended At",
+                    "Duration",
+                    "Status",
+                    "Bot Start Seconds",
+                    "Cold Start",
+                ],
+                [
+                    (
+                        s["sessionId"],
+                        format_timestamp(s["createdAt"]),
+                        format_timestamp(s["endedAt"]) if s["endedAt"] else "",
+                        format_duration(s["createdAt"], s["endedAt"]) or "",
+                        ("Error (500)" if s.get("completionStatus") == "500" else "Complete")
+                        if s["endedAt"]
+                        else "Active",
+                        s["botStartSeconds"] if s["botStartSeconds"] is not None else "",
+                        s["coldStart"],
+                    )
+                    for s in sessions_list
+                    if not session_id or s["sessionId"] == session_id
+                ],
+                title=f"Session data for agent {agent_name} ({org})",
+            )
+            return
 
         completed_sessions = [s for s in sessions_list if s.get("endedAt")]
 
@@ -705,6 +784,7 @@ async def delete(
     org = organization or config.get("org")
 
     if not force:
+        console.require_interactive("--force")
         if not await questionary.confirm(
             "Are you sure you want to delete this agent? Note: active sessions will not be interrupted and will continue to run until completion."
         ).ask_async():
@@ -759,6 +839,25 @@ async def deployments(
                 response.raise_for_status()
 
             data = await response.json()
+
+            if not console.rich_output:
+                console.print_records(
+                    ["ID", "Node Type", "Image", "Created At", "Updated At"],
+                    [
+                        (
+                            deployment.get("id", "N/A"),
+                            deployment.get("manifest", {})
+                            .get("spec", {})
+                            .get("dailyNodeType", "N/A"),
+                            deployment.get("manifest", {}).get("spec", {}).get("image", "N/A"),
+                            deployment.get("createdAt", "N/A"),
+                            deployment.get("updatedAt", "N/A"),
+                        )
+                        for deployment in data["deployments"]
+                    ],
+                    title=f"Deployments for agent: {agent_name}",
+                )
+                return
 
             table = Table(
                 show_header=True,
@@ -906,14 +1005,15 @@ async def start(
                 border_style="yellow",
             )
         )
+        console.require_interactive("--force")
         if not await questionary.confirm(
             "Are you sure you want to start an active session for this agent?"
         ).ask_async():
             console.print("[bold]Aborting start request[/bold]")
             raise typer.Exit(1)
 
-    with Live(
-        console.status("[dim]Checking agent health...[/dim]", spinner="dots"), refresh_per_second=4
+    with console.status(
+        "[dim]Checking agent health...[/dim]", spinner="dots", refresh_per_second=4
     ) as live:
         health_data, error = await API.agent(agent_name=agent_name, org=org, live=live)
         if not health_data or not health_data["ready"]:
@@ -923,12 +1023,7 @@ async def start(
             )
             raise typer.Exit(1)
 
-        live.update(
-            console.status(
-                f"[dim]Agent '{agent_name}' is healthy, sending start request...[/dim]",
-                spinner="dots",
-            )
-        )
+        live.update(f"[dim]Agent '{agent_name}' is healthy, sending start request...[/dim]")
 
         data, error = await API.start_agent(
             agent_name=agent_name,
@@ -1009,6 +1104,7 @@ async def stop(
                 border_style="yellow",
             )
         )
+        console.require_interactive("--force")
         if not await questionary.confirm("Are you sure you want to stop this session?").ask_async():
             console.print("[bold]Aborting stop request[/bold]")
             raise typer.Exit(1)

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -124,6 +124,8 @@ async def list_agents(
             )
             raise typer.Exit(1)
 
+        elif console.json_output:
+            console.output_json({"agents": data})
         elif not console.rich_output:
             console.print_records(
                 ["Name", "Region", "Agent ID", "Active Deployment ID", "Created At", "Updated At"],
@@ -190,6 +192,10 @@ async def status(
         if not data:
             console.error(f"No deployment data found for agent with name '{agent_name}'")
             raise typer.Exit(1)
+
+        if console.json_output:
+            console.output_json(data)
+            return
 
         if not console.rich_output:
             spec = data.get("deployment", {}).get("manifest", {}).get("spec", {})
@@ -447,6 +453,10 @@ async def sessions(
             if error:
                 raise typer.Exit(1)
 
+            if data and console.json_output:
+                console.output_json(data)
+                return
+
             if not data:
                 console.error(f"Session '{session_id}' not found")
                 raise typer.Exit(1)
@@ -534,6 +544,10 @@ async def sessions(
 
         sessions_list = data.get("sessions", [])
         total_sessions = len(sessions_list)
+
+        if console.json_output:
+            console.output_json(data)
+            return
 
         if not console.rich_output:
             console.print_records(
@@ -741,6 +755,10 @@ async def logs(
             console.print("[dim]No logs found for agent[/dim]")
             raise typer.Exit(1)
 
+    if console.json_output:
+        console.output_json(data)
+        return
+
     for log in data["logs"]:
         log_data = log.get("log", "")
         if log_data:
@@ -839,6 +857,10 @@ async def deployments(
                 response.raise_for_status()
 
             data = await response.json()
+
+            if console.json_output:
+                console.output_json(data)
+                return
 
             if not console.rich_output:
                 console.print_records(
@@ -1040,6 +1062,9 @@ async def start(
             raise typer.Exit(1)
 
         live.stop()
+
+        if console.json_output:
+            console.output_json(data if isinstance(data, dict) else {})
 
         console.success(f"Agent '{agent_name}' started successfully")
 

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -108,7 +108,7 @@ async def list_agents(
         console.print(
             f"[red]Invalid region '{region}'. Valid regions are: {', '.join(valid_regions)}[/red]"
         )
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     with console.status(
         f"[dim]Fetching agents for organization: [bold]'{org}'[/bold][/dim]", spinner="dots"
@@ -116,14 +116,14 @@ async def list_agents(
         data, error = await API.agents(org=org, region=region)
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
         if not data or len(data) == 0:
             console.error(
                 f"[red]No agents found for namespace / organization '{org}'[/red]\n\n"
                 f"[dim]Please deploy an agent first using[/dim] [bold cyan]{PIPECAT_CLI_NAME} deploy[/bold cyan]"
             )
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         else:
             table = Table(show_header=True, show_lines=True, border_style="dim", box=box.SIMPLE)
@@ -170,11 +170,11 @@ async def status(
         live.stop()
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
         if not data:
             console.error(f"No deployment data found for agent with name '{agent_name}'")
-            return typer.Exit()
+            raise typer.Exit(1)
 
         # Deployment info
 
@@ -383,7 +383,7 @@ async def sessions(
             agent_name = deploy_config.agent_name
         else:
             console.error("No target agent name provided")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     # If session_id is specified, fetch single session with detailed metrics
     if session_id:
@@ -396,11 +396,11 @@ async def sessions(
             live.stop()
 
             if error:
-                return typer.Exit()
+                raise typer.Exit(1)
 
             if not data:
                 console.error(f"Session '{session_id}' not found")
-                return typer.Exit()
+                raise typer.Exit(1)
 
             # Display detailed session view
             session_duration = format_duration(data.get("createdAt"), data.get("endedAt")) or "N/A"
@@ -477,11 +477,11 @@ async def sessions(
         live.stop()
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
         if not data:
             console.error(f"No session data found for agent with name '{agent_name}'")
-            return typer.Exit()
+            raise typer.Exit(1)
 
         sessions_list = data.get("sessions", [])
         total_sessions = len(sessions_list)
@@ -660,7 +660,7 @@ async def logs(
 
         if not data or not data.get("logs"):
             console.print("[dim]No logs found for agent[/dim]")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     for log in data["logs"]:
         log_data = log.get("log", "")
@@ -709,17 +709,17 @@ async def delete(
             "Are you sure you want to delete this agent? Note: active sessions will not be interrupted and will continue to run until completion."
         ).ask_async():
             console.print("[bold]Aborting delete request[/bold]")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     with console.status(f"[dim]Deleting agent: [bold]'{agent_name}'[/bold][/dim]", spinner="dots"):
         data, error = await API.agent_delete(agent_name=agent_name, org=org)
 
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         if not data:
             console.error(f"Agent '{agent_name}' not found in namespace / organization '{org}'")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         console.success(f"Agent '{agent_name}' deleted successfully")
 
@@ -792,6 +792,7 @@ async def deployments(
     except Exception as e:
         logger.debug(e)
         console.api_error(error_code, f"Unable to get deployments for {agent_name}")
+        raise typer.Exit(1)
 
 
 @agent_cli.command(name="start", help="Start an agent instance")
@@ -860,7 +861,7 @@ async def start(
 
         if not default_agent_name:
             console.error("No target agent name provided")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         agent_name = default_agent_name
 
@@ -875,7 +876,7 @@ async def start(
             )
         )
 
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     # Validate daily_properties JSON if provided
     if use_daily and daily_properties:
@@ -884,7 +885,7 @@ async def start(
         except json.JSONDecodeError as e:
             console.error(f"Invalid JSON format for Daily room properties: {daily_properties}")
             console.print(f"[dim]JSON error: {str(e)}[/dim]")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     # Confirm start request
     if not force:
@@ -909,7 +910,7 @@ async def start(
             "Are you sure you want to start an active session for this agent?"
         ).ask_async():
             console.print("[bold]Aborting start request[/bold]")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     with Live(
         console.status("[dim]Checking agent health...[/dim]", spinner="dots"), refresh_per_second=4
@@ -920,7 +921,7 @@ async def start(
             console.error(
                 f"Agent '{agent_name}' does not exist or is not in a healthy state. Please check the agent status with [bold cyan]{PIPECAT_CLI_NAME} agent status {agent_name}[/bold cyan]"
             )
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         live.update(
             console.status(
@@ -941,7 +942,7 @@ async def start(
         if error:
             live.stop()
             # Error is displayed from start_agent create_api_method wrapper
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         live.stop()
 
@@ -996,7 +997,7 @@ async def stop(
             agent_name = partial_config.agent_name
         else:
             console.error("No target agent name provided")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     # Confirm stop request
     if not force:
@@ -1010,7 +1011,7 @@ async def stop(
         )
         if not await questionary.confirm("Are you sure you want to stop this session?").ask_async():
             console.print("[bold]Aborting stop request[/bold]")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     with console.status(
         f"[dim]Stopping session [bold]'{session_id}'[/bold] for agent [bold]'{agent_name}'[/bold][/dim]",
@@ -1021,6 +1022,6 @@ async def stop(
         )
 
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         console.success(f"Session '{session_id}' stopped successfully")

--- a/src/pipecatcloud/cli/commands/auth.py
+++ b/src/pipecatcloud/cli/commands/auth.py
@@ -18,7 +18,6 @@ import aiohttp
 import typer
 from loguru import logger
 from rich.columns import Columns
-from rich.live import Live
 
 from pipecatcloud.__version__ import version as _cli_version
 from pipecatcloud._utils.async_utils import synchronizer
@@ -592,18 +591,13 @@ async def whomai():
     org = config.get("org")
 
     try:
-        with Live(
-            console.status("[dim]Requesting current user data...[/dim]", spinner="dots"),
-            transient=True,
-        ) as live:
+        with console.status("[dim]Requesting current user data...[/dim]", spinner="dots") as live:
             user_data, error = await API.whoami(live=live)
 
             if error:
                 raise typer.Exit(1)
 
-            live.update(
-                console.status("[dim]Requesting user namespace / organization data...[/dim]")
-            )
+            live.update("[dim]Requesting user namespace / organization data...[/dim]")
 
             # Retrieve default user organization
             account, error = await API.organizations_current(org=org, live=live)
@@ -617,7 +611,7 @@ async def whomai():
             # Retrieve user Daily API key
             # Note: we don't raise an error if this fails, as it's not required for
             # the CLI to function
-            live.update(console.status("[dim]Fetching Daily API key...[/dim]", spinner="dots"))
+            live.update("[dim]Fetching Daily API key...[/dim]")
 
             daily_api_key = None
             try:

--- a/src/pipecatcloud/cli/commands/auth.py
+++ b/src/pipecatcloud/cli/commands/auth.py
@@ -599,10 +599,12 @@ async def whomai():
 
             live.update("[dim]Requesting user namespace / organization data...[/dim]")
 
-            # Retrieve default user organization
+            # Retrieve default user organization. The API wrapper already
+            # reported the error (create_api_method calls print_error), so
+            # don't report it again here — in json mode a second call would
+            # put a second {"error": ...} object on stdout.
             account, error = await API.organizations_current(org=org, live=live)
             if error:
-                API.print_error()
                 raise typer.Exit(1)
 
             if not account["name"] or not account["verbose_name"]:
@@ -613,9 +615,14 @@ async def whomai():
             # the CLI to function
             live.update("[dim]Fetching Daily API key...[/dim]")
 
+            # Bubbled because this failure is non-fatal: without bubbling, the
+            # API wrapper would render an error (and in json mode emit an
+            # {"error": ...} object to stdout) for a command that succeeds.
             daily_api_key = None
             try:
-                daily_api_key, error = await API.organizations_daily_key(org=org, live=live)
+                daily_api_key, error = await API.bubble_error().organizations_daily_key(
+                    org=org, live=live
+                )
             except Exception:
                 pass
 

--- a/src/pipecatcloud/cli/commands/auth.py
+++ b/src/pipecatcloud/cli/commands/auth.py
@@ -620,6 +620,17 @@ async def whomai():
                 pass
 
             live.stop()
+
+            if console.json_output:
+                console.output_json(
+                    {
+                        "user": user_data.get("user"),
+                        "organization": account,
+                        "dailyApiKey": daily_api_key,
+                    }
+                )
+                return
+
             emails = user_data.get("user", {}).get("emails", [])
             email = emails[0]["emailAddress"] if emails else user_data["user"]["userId"]
 

--- a/src/pipecatcloud/cli/commands/auth.py
+++ b/src/pipecatcloud/cli/commands/auth.py
@@ -362,7 +362,7 @@ async def login():
         oidc = await _fetch_oidc_discovery(oauth_config["issuer"])
     except Exception as e:
         console.error(f"Failed to fetch authentication configuration: {e}")
-        return
+        raise typer.Exit(1)
 
     authorize_url_base = oidc["authorization_endpoint"]
     token_url = oidc["token_endpoint"]
@@ -374,7 +374,7 @@ async def login():
         runner, port, result_future = await _start_callback_server()
     except RuntimeError as e:
         console.error(str(e))
-        return
+        raise typer.Exit(1)
 
     redirect_uri = f"http://{CALLBACK_HOST}:{port}{CALLBACK_PATH}"
 
@@ -411,16 +411,16 @@ async def login():
             auth_code, returned_state = await asyncio.wait_for(result_future, timeout=120.0)
         except TimeoutError:
             console.error("Authentication timed out.")
-            return
+            raise typer.Exit(1)
 
         if not auth_code:
             console.error("Authentication was cancelled or failed.")
-            return
+            raise typer.Exit(1)
 
         # Verify state to prevent CSRF
         if returned_state != state:
             console.error("Authentication failed: state mismatch (possible CSRF attack).")
-            return
+            raise typer.Exit(1)
 
         # Exchange code for tokens
         try:
@@ -429,7 +429,7 @@ async def login():
             )
         except RuntimeError as e:
             console.error(f"Token exchange failed: {e}")
-            return
+            raise typer.Exit(1)
 
     finally:
         await runner.cleanup()
@@ -448,10 +448,12 @@ async def login():
                 "Have you completed the onboarding process? "
                 "Please first sign in via the web dashboard."
             )
-            return
+            raise typer.Exit(1)
+    except typer.Exit:
+        raise
     except Exception:
         console.error("Failed to retrieve account information.")
-        return
+        raise typer.Exit(1)
 
     # Store credentials
     update_user_config(
@@ -532,7 +534,7 @@ async def _use_pat_impl(token: str):
     """Core logic for use-pat command, extracted for testability."""
     if not token.startswith("pcc_pat_"):
         console.error("Invalid token format. PATs must start with [bold]pcc_pat_[/bold]")
-        return
+        raise typer.Exit(1)
 
     # Verify the PAT works by fetching the user's organizations
     # Preserve the currently active org if set
@@ -545,10 +547,12 @@ async def _use_pat_impl(token: str):
                     "Token is valid but account has no associated namespace. "
                     "Have you completed the onboarding process?"
                 )
-                return
+                raise typer.Exit(1)
+    except typer.Exit:
+        raise
     except Exception:
         console.error("Invalid or expired token.")
-        return
+        raise typer.Exit(1)
 
     # Store PAT — clear OAuth-specific fields since they don't apply
     update_user_config(
@@ -572,7 +576,7 @@ async def use_pat():
     token = getpass.getpass("Personal Access Token: ")
     if not token:
         console.error("No token provided.")
-        return
+        raise typer.Exit(1)
     await _use_pat_impl(token)
 
 
@@ -595,7 +599,7 @@ async def whomai():
             user_data, error = await API.whoami(live=live)
 
             if error:
-                return typer.Exit()
+                raise typer.Exit(1)
 
             live.update(
                 console.status("[dim]Requesting user namespace / organization data...[/dim]")
@@ -605,7 +609,7 @@ async def whomai():
             account, error = await API.organizations_current(org=org, live=live)
             if error:
                 API.print_error()
-                return typer.Exit()
+                raise typer.Exit(1)
 
             if not account["name"] or not account["verbose_name"]:
                 raise
@@ -641,5 +645,8 @@ async def whomai():
                 ]
             )
             console.success(message)
+    except typer.Exit:
+        raise
     except Exception:
         console.error("Unable to obtain user data. Please contact support")
+        raise typer.Exit(1)

--- a/src/pipecatcloud/cli/commands/build.py
+++ b/src/pipecatcloud/cli/commands/build.py
@@ -268,6 +268,29 @@ async def list_builds(
             console.print(f"[dim]Filter: status={status_filter}[/dim]")
         return
 
+    # Display with count info
+    showing_text = f"Showing {len(builds)}"
+    if total > len(builds):
+        showing_text += f" of {total}"
+    showing_text += " builds"
+
+    if not console.rich_output:
+        console.print_records(
+            ["Build ID", "Status", "Region", "Duration", "Created"],
+            [
+                (
+                    build.get("id", "N/A"),
+                    build.get("status", "unknown"),
+                    build.get("region", "N/A"),
+                    _format_duration(build.get("buildDurationSeconds")),
+                    format_timestamp(build.get("createdAt", "")),
+                )
+                for build in builds
+            ],
+            title=f"Cloud Builds ({showing_text})",
+        )
+        return
+
     # Create table
     table = Table(
         show_header=True,
@@ -290,12 +313,6 @@ async def list_builds(
             _format_duration(build.get("buildDurationSeconds")),
             format_timestamp(build.get("createdAt", "")),
         )
-
-    # Display with count info
-    showing_text = f"Showing {len(builds)}"
-    if total > len(builds):
-        showing_text += f" of {total}"
-    showing_text += " builds"
 
     console.success(
         table,

--- a/src/pipecatcloud/cli/commands/build.py
+++ b/src/pipecatcloud/cli/commands/build.py
@@ -83,6 +83,10 @@ async def logs(
             console.error(f"Build '{build_id}' not found")
             raise typer.Exit(1)
 
+    if console.json_output:
+        console.output_json(data)
+        return
+
     logs_list = data.get("logs", [])
 
     if not logs_list:
@@ -156,6 +160,10 @@ async def status(
             raise typer.Exit(1)
 
     build = data.get("build", data)
+
+    if console.json_output:
+        console.output_json(build)
+        return
 
     # Build info table
     info_lines = [
@@ -273,6 +281,10 @@ async def list_builds(
     if total > len(builds):
         showing_text += f" of {total}"
     showing_text += " builds"
+
+    if console.json_output:
+        console.output_json(data)
+        return
 
     if not console.rich_output:
         console.print_records(

--- a/src/pipecatcloud/cli/commands/build.py
+++ b/src/pipecatcloud/cli/commands/build.py
@@ -77,11 +77,11 @@ async def logs(
         data, error = await API.build_logs(org=org, build_id=build_id, limit=limit)
 
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         if not data:
             console.error(f"Build '{build_id}' not found")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     logs_list = data.get("logs", [])
 
@@ -149,11 +149,11 @@ async def status(
         data, error = await API.build_get(org=org, build_id=build_id)
 
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         if not data:
             console.error(f"Build '{build_id}' not found")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     build = data.get("build", data)
 
@@ -257,7 +257,7 @@ async def list_builds(
         )
 
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     builds = data.get("builds", [])
     total = data.get("total", len(builds))

--- a/src/pipecatcloud/cli/commands/build.py
+++ b/src/pipecatcloud/cli/commands/build.py
@@ -270,6 +270,12 @@ async def list_builds(
     builds = data.get("builds", [])
     total = data.get("total", len(builds))
 
+    # Before the empty-result return: an empty set must still emit a
+    # well-formed JSON payload rather than zero bytes on stdout.
+    if console.json_output:
+        console.output_json(data)
+        return
+
     if not builds:
         console.print("[dim]No builds found[/dim]")
         if status_filter:
@@ -281,10 +287,6 @@ async def list_builds(
     if total > len(builds):
         showing_text += f" of {total}"
     showing_text += " builds"
-
-    if console.json_output:
-        console.output_json(data)
-        return
 
     if not console.rich_output:
         console.print_records(

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -484,6 +484,16 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
             )
             raise typer.Exit(1)
 
+    if console.json_output:
+        console.output_json(
+            {
+                "agentName": params.agent_name,
+                "deploymentId": active_deployment_id,
+                "ready": is_ready,
+                "available": bool(last_status and last_status.is_available),
+            }
+        )
+
     if is_ready:
         public_api_key = config.get("default_public_key")
         extra_message = ""

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -284,7 +284,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
 
         if error:
             live.stop()
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         if data:
             existing_agent = True
@@ -296,7 +296,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
                     default=True,
                 ):
                     console.cancel()
-                    return typer.Exit()
+                    raise typer.Exit(1)
 
     # Start the deployment process
     with Live(
@@ -314,14 +314,14 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
             )
 
             if error:
-                return typer.Exit()
+                raise typer.Exit(1)
 
             if not secrets_exist:
                 live.stop()
                 console.error(
                     f"Secret set [bold]'{params.secret_set}'[/bold] not found in namespace [bold]'{org}'[/bold]"
                 )
-                return typer.Exit()
+                raise typer.Exit(1)
 
         """
         # 2. Check that provided image pull secret exists
@@ -335,7 +335,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
             sets, error = await API.secrets_list(org=org, live=live)
 
             if error:
-                return typer.Exit()
+                raise typer.Exit(1)
 
             # Image pull secrets are globally unique by name (region is validated
             # server-side at deploy), so match on name + type without region filter.
@@ -349,7 +349,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
                 console.error(
                     f"Image pull secret with name [bold]'{params.image_credentials}'[/bold] not found in namespace [bold]'{org}'[/bold]"
                 )
-                return typer.Exit()
+                raise typer.Exit(1)
 
         live.update(
             console.status(
@@ -362,12 +362,12 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
         )
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
         if not existing_agent and not result:
             live.stop()
             console.error("A problem occured during deployment. Please contact support.")
-            return typer.Exit()
+            raise typer.Exit(1)
 
         # Close the live display before starting the new polling phase
         live.stop()
@@ -434,11 +434,11 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
                             "Your deployment may still be in progress. Check it with "
                             f"`{PIPECAT_CLI_NAME} agent status {params.agent_name}`"
                         )
-                        return typer.Exit()
+                        raise typer.Exit(1)
                     # Non-transient error (4xx, auth, etc.) — abort immediately.
                     status.stop()
                     console.error("Error checking deployment status")
-                    return typer.Exit()
+                    raise typer.Exit(1)
 
                 # Successful poll — reset the transient-failure budget.
                 consecutive_failures = 0
@@ -454,7 +454,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
                         console.api_error(error_message, "Agent deployment failed")
                     else:
                         console.error(f"Deployment failed with an unknown error: {status_errors}")
-                    return typer.Exit()
+                    raise typer.Exit(1)
 
                 # Capture the deployment ID for display
                 desired_deployment_id = agent_status.get(
@@ -488,7 +488,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
             console.print(
                 "\n[yellow]Deployment monitoring interrupted. The deployment may still be in progress.[/yellow]"
             )
-            return typer.Exit()
+            raise typer.Exit(1)
 
     if is_ready:
         public_api_key = config.get("default_public_key")
@@ -532,14 +532,14 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
                 border_style="red",
             )
         )
+        raise typer.Exit(1)
     else:
         timeout_seconds = MAX_ALIVE_CHECKS * ALIVE_CHECK_SLEEP
         console.error(
             f"Deployment did not become available within {timeout_seconds} seconds.\n"
             f"Please check logs with `{PIPECAT_CLI_NAME} agent logs {params.agent_name}`"
         )
-
-    return typer.Exit()
+        raise typer.Exit(1)
 
 
 def create_deploy_command(app: typer.Typer):
@@ -712,7 +712,7 @@ def create_deploy_command(app: typer.Typer):
             console.error(
                 f"Invalid region '{deploy_region}'. Valid regions are: {', '.join(valid_regions)}"
             )
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         # Handle Krisp VIVA configuration
         if krisp_viva_audio_filter is not None:
@@ -721,7 +721,7 @@ def create_deploy_command(app: typer.Typer):
         # Assert agent name is provided
         if not partial_config.agent_name:
             console.error("Agent name is required")
-            return typer.Exit()
+            raise typer.Exit(1)
 
         # Track if we're using cloud build (either from --build-id or interactive build)
         using_cloud_build = bool(partial_config.build_id)
@@ -758,13 +758,13 @@ def create_deploy_command(app: typer.Typer):
                 )
 
                 if not build_id:
-                    return typer.Exit(1)
+                    raise typer.Exit(1)
 
                 partial_config.build_id = build_id
                 using_cloud_build = True
             else:
                 console.cancel()
-                return typer.Exit()
+                raise typer.Exit(1)
 
         # Assert credentials are provided if not using --no-credentials / force flag
         # Skip this check for cloud builds (they use managed credentials)
@@ -780,7 +780,7 @@ def create_deploy_command(app: typer.Typer):
                 subtitle="Learn more: https://docs.pipecat.ai/pipecat-cloud/fundamentals/secrets#image-pull-secrets",
                 title_extra="Attempt to deploy without repository credentials",
             )
-            return typer.Exit()
+            raise typer.Exit(1)
 
         # Create and display table
         table = Table(show_header=False, border_style="dim", show_edge=True, show_lines=True)
@@ -799,7 +799,7 @@ def create_deploy_command(app: typer.Typer):
             # Fetch org's default region to show user what will be used
             props, error = await API.properties(org)
             if error:
-                return typer.Exit()
+                raise typer.Exit(1)
             region_display = (
                 f"[green]{props['defaultRegion']}[/green] [dim](organization default)[/dim]"
             )
@@ -874,7 +874,7 @@ def create_deploy_command(app: typer.Typer):
             "\nDo you want to proceed with deployment?", default=True
         ):
             console.cancel()
-            return typer.Abort()
+            raise typer.Abort()
 
         # Deploy method posts the deployment config to the API
         # and polls the deployment status until it's ready

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -255,10 +255,11 @@ async def _cloud_build_flow(
 
     if success:
         duration = final_build.get("buildDurationSeconds")
+        # Duration lives in the title; repeating it in the body rendered as a
+        # dangling unitless "Duration: 99" in plain mode.
         duration_str = f" ({duration}s)" if duration else ""
         console.success(
-            f"[bold white]Build ID:[/bold white] {build_id}\n"
-            f"[bold white]Duration:[/bold white] {duration_str.strip('() s') if duration else 'N/A'}",
+            f"[bold white]Build ID:[/bold white] {build_id}",
             title=f"Build Complete{duration_str}",
         )
         return build_id
@@ -787,15 +788,11 @@ def create_deploy_command(app: typer.Typer):
             )
             raise typer.Exit(1)
 
-        # Create and display table
-        table = Table(show_header=False, border_style="dim", show_edge=True, show_lines=True)
-        table.add_column("Property", style="cyan")
-        table.add_column("Value", style="green")
-        table.add_row("Min agents", str(partial_config.scaling.min_agents))
-        if partial_config.scaling.max_agents:
-            table.add_row("Max agents", str(partial_config.scaling.max_agents))
-        else:
-            table.add_row("Max agents", "[dim]Use existing or default[/dim]")
+        max_agents_display = (
+            str(partial_config.scaling.max_agents)
+            if partial_config.scaling.max_agents
+            else "[dim]Use existing or default[/dim]"
+        )
 
         # Resolve region display - fetch org default if not explicitly specified
         if partial_config.region:
@@ -851,29 +848,30 @@ def create_deploy_command(app: typer.Typer):
             ]
         )
 
-        content = Group(
-            *content_items,
-            table,
-            *(
-                [
-                    Text(
-                        f"Note: Usage costs will apply for {partial_config.scaling.min_agents} reserved agent(s). Please see: https://www.daily.co/pricing/pipecat-cloud/",
-                        style="red",
-                    )
-                ]
-                if partial_config.scaling.min_agents
-                else [
-                    Text(
-                        "Note: Deploying with 0 minimum agents may result in cold starts",
-                        style="red",
-                    )
-                ]
-            ),
+        cost_note = (
+            f"Note: Usage costs will apply for {partial_config.scaling.min_agents} reserved agent(s). Please see: https://www.daily.co/pricing/pipecat-cloud/"
+            if partial_config.scaling.min_agents
+            else "Note: Deploying with 0 minimum agents may result in cold starts"
         )
 
-        console.print(
-            Panel(content, title="Review deployment", title_align="left", border_style="yellow")
-        )
+        if not console.rich_output:
+            console.print("Review deployment:")
+            for item in content_items:
+                console.print(item)
+            console.print(f"Min agents: {partial_config.scaling.min_agents}")
+            console.print(f"Max agents: {max_agents_display}")
+            console.print(cost_note)
+        else:
+            table = Table(show_header=False, border_style="dim", show_edge=True, show_lines=True)
+            table.add_column("Property", style="cyan")
+            table.add_column("Value", style="green")
+            table.add_row("Min agents", str(partial_config.scaling.min_agents))
+            table.add_row("Max agents", max_agents_display)
+
+            content = Group(*content_items, table, Text(cost_note, style="red"))
+            console.print(
+                Panel(content, title="Review deployment", title_align="left", border_style="yellow")
+            )
 
         if not auto_yes:
             console.require_interactive("--yes")

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import typer
 from loguru import logger
 from rich.console import Group
-from rich.live import Live
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -127,6 +126,7 @@ async def _cloud_build_flow(
                 border_style="cyan",
             )
         )
+        console.require_interactive("--yes")
         if not typer.confirm("Proceed with cloud build?", default=True):
             console.cancel()
             return None
@@ -233,15 +233,17 @@ async def _cloud_build_flow(
     # Poll for completion
     last_status = None
 
-    def status_callback(build):
-        nonlocal last_status
-        status = build.get("status", "unknown")
-        if status != last_status:
-            last_status = status
-
     with console.status(
         "[dim]Building image (this may take a few minutes)...[/dim]", spinner="bouncingBar"
-    ):
+    ) as build_status:
+
+        def status_callback(build):
+            nonlocal last_status
+            status = build.get("status", "unknown")
+            if status != last_status:
+                last_status = status
+                build_status.update(f"[dim]Build status: {status}[/dim]")
+
         success, final_build = await poll_build_status(
             build_id=build_id,
             org=org,
@@ -276,9 +278,8 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
     existing_agent = False
 
     # Check for an existing deployment with this agent name
-    with Live(
-        console.status("[dim]Checking for existing agent deployment...[/dim]", spinner="dots"),
-        transient=True,
+    with console.status(
+        "[dim]Checking for existing agent deployment...[/dim]", spinner="dots"
     ) as live:
         data, error = await API.agent(agent_name=params.agent_name, org=org, live=live)
 
@@ -291,6 +292,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
 
             if not force:
                 live.stop()
+                console.require_interactive("--yes")
                 if not typer.confirm(
                     f"Deployment for agent '{params.agent_name}' exists. Do you want to update it? Note: this will not interrupt any active sessions",
                     default=True,
@@ -299,16 +301,12 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
                     raise typer.Exit(1)
 
     # Start the deployment process
-    with Live(
-        console.status("[dim]Preparing deployment...", spinner="dots"), transient=True
-    ) as live:
+    with console.status("[dim]Preparing deployment...", spinner="dots") as live:
         """
         # 1. Check that provided secret set exists
         """
         if params.secret_set:
-            live.update(
-                console.status(f"[dim]Verifying secret set {params.secret_set} exists...[/dim]")
-            )
+            live.update(f"[dim]Verifying secret set {params.secret_set} exists...[/dim]")
             secrets_exist, error = await API.secrets_list(
                 secret_set=params.secret_set, org=org, live=live
             )
@@ -328,9 +326,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
         """
         if params.image_credentials:
             live.update(
-                console.status(
-                    f"[dim]Verifying image pull secret {params.image_credentials} exists...[/dim]"
-                )
+                f"[dim]Verifying image pull secret {params.image_credentials} exists...[/dim]"
             )
             sets, error = await API.secrets_list(org=org, live=live)
 
@@ -352,9 +348,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
                 raise typer.Exit(1)
 
         live.update(
-            console.status(
-                f"[dim]{'Updating' if existing_agent else 'Pushing'} agent manifest for[/dim] [cyan]'{params.agent_name}'[/cyan]"
-            )
+            f"[dim]{'Updating' if existing_agent else 'Pushing'} agent manifest for[/dim] [cyan]'{params.agent_name}'[/cyan]"
         )
 
         result, error = await API.deploy(
@@ -744,6 +738,7 @@ def create_deploy_command(app: typer.Typer):
                         border_style="yellow",
                     )
                 )
+                console.require_interactive("--yes")
                 should_build = typer.confirm(
                     "Would you like to build with Pipecat Cloud?",
                     default=True,
@@ -870,11 +865,11 @@ def create_deploy_command(app: typer.Typer):
             Panel(content, title="Review deployment", title_align="left", border_style="yellow")
         )
 
-        if not auto_yes and not typer.confirm(
-            "\nDo you want to proceed with deployment?", default=True
-        ):
-            console.cancel()
-            raise typer.Abort()
+        if not auto_yes:
+            console.require_interactive("--yes")
+            if not typer.confirm("\nDo you want to proceed with deployment?", default=True):
+                console.cancel()
+                raise typer.Abort()
 
         # Deploy method posts the deployment config to the API
         # and polls the deployment status until it's ready

--- a/src/pipecatcloud/cli/commands/docker.py
+++ b/src/pipecatcloud/cli/commands/docker.py
@@ -347,6 +347,7 @@ async def build_push(
         )
     )
 
+    console.require_interactive(None)
     if not typer.confirm("Do you want to proceed with the build?", default=True):
         console.cancel()
         raise typer.Exit(1)

--- a/src/pipecatcloud/cli/commands/docker.py
+++ b/src/pipecatcloud/cli/commands/docker.py
@@ -226,6 +226,13 @@ async def build_push(
         help="Do not tag as 'latest'",
         rich_help_panel="Build Configuration",
     ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Automatic yes to the build confirmation (for CI/CD automation)",
+        rich_help_panel="Build Configuration",
+    ),
 ):
     """Build, tag, and optionally push a Docker image for your agent."""
 
@@ -347,10 +354,11 @@ async def build_push(
         )
     )
 
-    console.require_interactive(None)
-    if not typer.confirm("Do you want to proceed with the build?", default=True):
-        console.cancel()
-        raise typer.Exit(1)
+    if not yes:
+        console.require_interactive("--yes")
+        if not typer.confirm("Do you want to proceed with the build?", default=True):
+            console.cancel()
+            raise typer.Exit(1)
 
     # Execute build
     console.print("\n[bold cyan]Building Docker image...[/bold cyan]")

--- a/src/pipecatcloud/cli/commands/docker.py
+++ b/src/pipecatcloud/cli/commands/docker.py
@@ -277,26 +277,26 @@ async def build_push(
     # Validate required parameters
     if not final_agent_name:
         console.error("Agent name is required. Provide via argument or pcc-deploy.toml")
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     if not no_push:
         if not final_registry:
             console.error(
                 "Registry type is required when pushing. Use --registry or configure in pcc-deploy.toml"
             )
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         if not final_username:
             console.error(
                 "Registry username is required when pushing. Use --username or configure in pcc-deploy.toml"
             )
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         if final_registry == RegistryType.CUSTOM and not final_registry_url:
             console.error(
                 "Registry URL is required for custom registries. Use --registry-url or configure in pcc-deploy.toml"
             )
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     # Build image name
     if no_push:
@@ -309,7 +309,7 @@ async def build_push(
             )
         except ValueError as e:
             console.error(str(e))
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     # Prepare image tags
     version_tag = f"{base_image_name}:{final_version}"
@@ -349,12 +349,12 @@ async def build_push(
 
     if not typer.confirm("Do you want to proceed with the build?", default=True):
         console.cancel()
-        return typer.Exit()
+        raise typer.Exit(1)
 
     # Execute build
     console.print("\n[bold cyan]Building Docker image...[/bold cyan]")
     if not run_docker_command(build_command, f"Building {final_agent_name}", stream_output=True):
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     console.success(f"Successfully built image(s): {', '.join(tags_display)}")
 
@@ -375,7 +375,7 @@ async def build_push(
             stream_output=False,
             registry_info=registry_info,
         ):
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         # Push latest tag if created
         if not final_no_latest:
@@ -385,7 +385,7 @@ async def build_push(
                 stream_output=False,
                 registry_info=registry_info,
             ):
-                return typer.Exit(1)
+                raise typer.Exit(1)
 
         pushed_tags = [version_tag]
         if not final_no_latest:

--- a/src/pipecatcloud/cli/commands/organizations.py
+++ b/src/pipecatcloud/cli/commands/organizations.py
@@ -13,7 +13,7 @@ from rich.table import Table
 
 from pipecatcloud._utils.async_utils import synchronizer
 from pipecatcloud._utils.auth_utils import requires_login
-from pipecatcloud._utils.console_utils import console
+from pipecatcloud._utils.console_utils import console, stdin_is_interactive
 from pipecatcloud.cli import PIPECAT_CLI_NAME
 from pipecatcloud.cli.api import API
 from pipecatcloud.cli.config import (
@@ -51,6 +51,7 @@ async def select(organization: str = typer.Option(None, "--organization", "-o"))
     try:
         selected_org = None, None
         if not organization:
+            console.require_interactive("--organization")
             # Prompt user to select organization
             value = await questionary.select(
                 "Select default namespace / organization",
@@ -117,6 +118,20 @@ async def list_organizations():
         )
         raise typer.Exit(1)
 
+    if not console.rich_output:
+        console.print_records(
+            ["Organization", "Name", "Active"],
+            [
+                (
+                    org["verboseName"],
+                    org["name"],
+                    "active" if current_org and org["name"] == current_org else "",
+                )
+                for org in org_list
+            ],
+        )
+        return
+
     table = Table(border_style="dim", box=box.SIMPLE, show_edge=True, show_lines=False)
     table.add_column("Organization", style="white")
     table.add_column("Name", style="white")
@@ -163,6 +178,22 @@ async def keys(
                 f"[bold]{PIPECAT_CLI_NAME} organizations keys create[/bold] command.[/dim]"
             )
             raise typer.Exit(1)
+
+        if not console.rich_output:
+            console.print_records(
+                ["Name", "Key", "Created At", "Status"],
+                [
+                    (
+                        key["metadata"]["name"],
+                        key["key"],
+                        key["createdAt"],
+                        "Revoked" if key["revoked"] else "Active",
+                    )
+                    for key in data["public"]
+                ],
+                title=f"API keys for organization: {org}",
+            )
+            return
 
         table = Table(
             show_header=True,
@@ -213,6 +244,7 @@ async def create_key(
     org = organization or config.get("org")
 
     if not api_key_name:
+        console.require_interactive("--name")
         api_key_name = await questionary.text(
             "Enter human readable name for API key e.g. 'Pipecat Key'"
         ).ask_async()
@@ -234,9 +266,11 @@ async def create_key(
         console.error("Invalid response from server. Please contact support.")
         raise typer.Exit(1)
 
-    # Determine as to whether we should make this key the active default
+    # Determine as to whether we should make this key the active default.
+    # Non-interactively (key already created at this point, so failing here
+    # would be worse than proceeding) fall back to the prompt's default: no.
     make_active = default
-    if not default:
+    if not default and stdin_is_interactive():
         make_active = await questionary.confirm(
             "Would you like to make this key the default key in your local configuration?",
             default=False,
@@ -252,6 +286,13 @@ async def create_key(
         )
     else:
         console.print("[dim]Bypassing using key as default")
+
+    if not console.rich_output:
+        console.print_records(
+            ["Name", "Key", "Organization"],
+            [(api_key_name, data["key"], org)],
+        )
+        return
 
     table = Table(
         show_header=True,
@@ -308,6 +349,7 @@ async def _revoke_key_flow(organization: str | None) -> None:
         raise typer.Exit(1)
 
     # Prompt user to revoke a key
+    console.require_interactive(None)
     key = await questionary.select(
         "Select API key to revoke",
         choices=[
@@ -390,6 +432,7 @@ async def use_key(
         raise typer.Exit(1)
 
     # Prompt user to use a key
+    console.require_interactive(None)
     key = await questionary.select(
         "Select API key to use",
         choices=[
@@ -441,6 +484,14 @@ async def properties_list(
         console.print("[dim]No properties configured.[/dim]")
         return
 
+    if not console.rich_output:
+        console.print_records(
+            ["Property", "Value"],
+            [(prop_name, prop_value) for prop_name, prop_value in data.items()],
+            title=f"Properties for organization: {org}",
+        )
+        return
+
     table = Table(
         show_header=True,
         show_lines=False,
@@ -480,6 +531,23 @@ async def properties_schema(
 
     if not data:
         console.print("[dim]No properties available.[/dim]")
+        return
+
+    if not console.rich_output:
+        console.print_records(
+            ["Property", "Type", "Current Value", "Default", "Description"],
+            [
+                (
+                    prop_name,
+                    prop_info.get("type", ""),
+                    prop_info.get("currentValue", ""),
+                    prop_info.get("default", ""),
+                    prop_info.get("description", ""),
+                )
+                for prop_name, prop_info in data.items()
+            ],
+            title=f"Properties schema for organization: {org}",
+        )
         return
 
     table = Table(

--- a/src/pipecatcloud/cli/commands/organizations.py
+++ b/src/pipecatcloud/cli/commands/organizations.py
@@ -46,7 +46,7 @@ async def select(organization: str = typer.Option(None, "--organization", "-o"))
         org_list, error = await API.organizations()
 
         if error:
-            typer.Exit()
+            raise typer.Exit(1)
 
     try:
         selected_org = None, None
@@ -65,7 +65,7 @@ async def select(organization: str = typer.Option(None, "--organization", "-o"))
             ).ask_async()
 
             if not value:
-                return typer.Exit(1)
+                raise typer.Exit(1)
 
             selected_org = value[0], value[1]
 
@@ -79,7 +79,7 @@ async def select(organization: str = typer.Option(None, "--organization", "-o"))
                 console.error(
                     f"Unable to find namespace [bold]'{organization}'[/bold] in user's available organizations"
                 )
-                return typer.Exit(1)
+                raise typer.Exit(1)
             selected_org = match["name"], match["verboseName"]
 
         update_user_config(None, selected_org[0])
@@ -89,8 +89,11 @@ async def select(organization: str = typer.Option(None, "--organization", "-o"))
             f"Current organization set to [bold green]{selected_org[1]} [dim]({selected_org[0]})[/dim][/bold green]\n"
             f"[dim]Default namespace updated in {user_config_path}[/dim]"
         )
+    except typer.Exit:
+        raise
     except Exception:
         console.error("Unable to update user credentials. Please contact support.")
+        raise typer.Exit(1)
 
 
 @organization_cli.command(name="list", help="List organizations user is a member of.")
@@ -105,14 +108,14 @@ async def list_organizations():
         org_list, error = await API.organizations()
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
     if not org_list or not len(org_list):
         console.error(
             "No namespaces associated with user account. Please complete onboarding via the dashboard.",
             subtitle=config.get("dashboard_host"),
         )
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     table = Table(border_style="dim", box=box.SIMPLE, show_edge=True, show_lines=False)
     table.add_column("Organization", style="white")
@@ -151,7 +154,7 @@ async def keys(
         data, error = await API.api_keys(org)
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
         if len(data["public"]) == 0:
             console.error(
@@ -159,7 +162,7 @@ async def keys(
                 f"[dim]Create a new API key with the "
                 f"[bold]{PIPECAT_CLI_NAME} organizations keys create[/bold] command.[/dim]"
             )
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         table = Table(
             show_header=True,
@@ -216,7 +219,7 @@ async def create_key(
 
     if not api_key_name or api_key_name == "":
         console.error("You must enter a name for the API key")
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     data = None
 
@@ -225,11 +228,11 @@ async def create_key(
     ):
         data, error = await API.api_key_create(api_key_name, org)
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     if not data or "key" not in data:
         console.error("Invalid response from server. Please contact support.")
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     # Determine as to whether we should make this key the active default
     make_active = default
@@ -283,7 +286,7 @@ async def _revoke_key_flow(organization: str | None) -> None:
         data, error = await API.api_keys(org)
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
         if len(data["public"]) == 0:
             console.error(
@@ -291,8 +294,7 @@ async def _revoke_key_flow(organization: str | None) -> None:
                 f"[dim]Create a new API key with the "
                 f"[bold]{PIPECAT_CLI_NAME} organizations keys create[/bold] command.[/dim]"
             )
-            typer.Exit(1)
-            return
+            raise typer.Exit(1)
 
     # Only offer keys that are not already revoked — revoking a revoked key
     # is a no-op on the server and confuses the interactive flow.
@@ -303,7 +305,7 @@ async def _revoke_key_flow(organization: str | None) -> None:
             "[bold]No active API keys to revoke.[/bold]\n"
             "[dim]All keys in this organization are already revoked.[/dim]"
         )
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     # Prompt user to revoke a key
     key = await questionary.select(
@@ -315,7 +317,7 @@ async def _revoke_key_flow(organization: str | None) -> None:
     ).ask_async()
 
     if not key:
-        typer.Exit(1)
+        raise typer.Exit(1)
 
     key_is_default = config.get("default_public_key") == key[1]
 
@@ -333,13 +335,13 @@ async def _revoke_key_flow(organization: str | None) -> None:
             )
         except Exception:
             console.error("Unable to remove default key from local user config")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     with console.status(f"[dim]Revoking API key with ID {key[0]}...[/dim]", spinner="dots"):
         data, error = await API.api_key_revoke(key[0], org)
 
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     console.success(f"API key with ID: [bold]'{key[0]}'[/bold] revoked successfully.")
 
@@ -377,7 +379,7 @@ async def use_key(
         data, error = await API.api_keys(org)
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
     if len(data["public"]) == 0:
         console.print(
@@ -385,8 +387,7 @@ async def use_key(
             f"[dim]Create a new API key with the "
             f"[bold]{PIPECAT_CLI_NAME} organizations keys create[/bold] command.[/dim]"
         )
-        typer.Exit(1)
-        return
+        raise typer.Exit(1)
 
     # Prompt user to use a key
     key = await questionary.select(
@@ -398,8 +399,7 @@ async def use_key(
     ).ask_async()
 
     if not key:
-        typer.Exit(1)
-        return
+        raise typer.Exit(1)
 
     try:
         update_user_config(
@@ -410,6 +410,7 @@ async def use_key(
     except Exception as e:
         logger.debug(e)
         console.error("Unable to set default key in local config. Please contact support.")
+        raise typer.Exit(1)
 
 
 # ---- Properties Commands ----
@@ -434,7 +435,7 @@ async def properties_list(
         data, error = await API.properties(org)
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
     if not data:
         console.print("[dim]No properties configured.[/dim]")
@@ -475,7 +476,7 @@ async def properties_schema(
         data, error = await API.properties_schema(org)
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
     if not data:
         console.print("[dim]No properties available.[/dim]")
@@ -536,11 +537,11 @@ async def properties_set(
         data, error = await API.properties_update(org, {property_name: value})
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
     if not data:
         console.error("Failed to update property.")
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     new_value = data.get(property_name, value)
     console.success(
@@ -576,11 +577,11 @@ async def default_region(
             data, error = await API.properties_update(org, {"defaultRegion": region})
 
             if error:
-                return typer.Exit()
+                raise typer.Exit(1)
 
         if not data:
             console.error("Failed to update default region.")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         console.success(
             f"Default region set to [bold green]{data.get('defaultRegion', region)}[/bold green]"
@@ -594,7 +595,7 @@ async def default_region(
             data, error = await API.properties_schema(org)
 
             if error:
-                return typer.Exit()
+                raise typer.Exit(1)
 
         if not data or "defaultRegion" not in data:
             console.print("[dim]No default region configured.[/dim]")

--- a/src/pipecatcloud/cli/commands/organizations.py
+++ b/src/pipecatcloud/cli/commands/organizations.py
@@ -118,6 +118,10 @@ async def list_organizations():
         )
         raise typer.Exit(1)
 
+    if console.json_output:
+        console.output_json({"organizations": org_list})
+        return
+
     if not console.rich_output:
         console.print_records(
             ["Organization", "Name", "Active"],
@@ -178,6 +182,10 @@ async def keys(
                 f"[bold]{PIPECAT_CLI_NAME} organizations keys create[/bold] command.[/dim]"
             )
             raise typer.Exit(1)
+
+        if console.json_output:
+            console.output_json(data)
+            return
 
         if not console.rich_output:
             console.print_records(
@@ -286,6 +294,10 @@ async def create_key(
         )
     else:
         console.print("[dim]Bypassing using key as default")
+
+    if console.json_output:
+        console.output_json(data)
+        return
 
     if not console.rich_output:
         console.print_records(
@@ -484,6 +496,10 @@ async def properties_list(
         console.print("[dim]No properties configured.[/dim]")
         return
 
+    if console.json_output:
+        console.output_json(data)
+        return
+
     if not console.rich_output:
         console.print_records(
             ["Property", "Value"],
@@ -531,6 +547,10 @@ async def properties_schema(
 
     if not data:
         console.print("[dim]No properties available.[/dim]")
+        return
+
+    if console.json_output:
+        console.output_json(data)
         return
 
     if not console.rich_output:

--- a/src/pipecatcloud/cli/commands/organizations.py
+++ b/src/pipecatcloud/cli/commands/organizations.py
@@ -492,12 +492,14 @@ async def properties_list(
         if error:
             raise typer.Exit(1)
 
-    if not data:
-        console.print("[dim]No properties configured.[/dim]")
+    # Before the empty-result return: an empty set must still emit a
+    # well-formed JSON payload rather than zero bytes on stdout.
+    if console.json_output:
+        console.output_json(data or {})
         return
 
-    if console.json_output:
-        console.output_json(data)
+    if not data:
+        console.print("[dim]No properties configured.[/dim]")
         return
 
     if not console.rich_output:
@@ -545,12 +547,14 @@ async def properties_schema(
         if error:
             raise typer.Exit(1)
 
-    if not data:
-        console.print("[dim]No properties available.[/dim]")
+    # Before the empty-result return: an empty set must still emit a
+    # well-formed JSON payload rather than zero bytes on stdout.
+    if console.json_output:
+        console.output_json(data or {})
         return
 
-    if console.json_output:
-        console.output_json(data)
+    if not data:
+        console.print("[dim]No properties available.[/dim]")
         return
 
     if not console.rich_output:

--- a/src/pipecatcloud/cli/commands/regions.py
+++ b/src/pipecatcloud/cli/commands/regions.py
@@ -28,13 +28,19 @@ async def list_regions():
         console.print("[yellow]No regions available[/yellow]")
         return
 
+    rows = [(region["code"], region["display_name"]) for region in regions]
+
+    if not console.rich_output:
+        console.print_records(["Code", "Name"], rows)
+        return
+
     # Create table
     table = Table(show_header=True, header_style="bold")
     table.add_column("Code")
     table.add_column("Name")
 
     # Add rows
-    for region in regions:
-        table.add_row(region["code"], region["display_name"])
+    for code, name in rows:
+        table.add_row(code, name)
 
     console.print(table)

--- a/src/pipecatcloud/cli/commands/regions.py
+++ b/src/pipecatcloud/cli/commands/regions.py
@@ -28,6 +28,10 @@ async def list_regions():
         console.print("[yellow]No regions available[/yellow]")
         return
 
+    if console.json_output:
+        console.output_json({"regions": regions})
+        return
+
     rows = [(region["code"], region["display_name"]) for region in regions]
 
     if not console.rich_output:

--- a/src/pipecatcloud/cli/commands/regions.py
+++ b/src/pipecatcloud/cli/commands/regions.py
@@ -24,12 +24,14 @@ async def list_regions():
     with console.status("[dim]Fetching available regions...[/dim]", spinner="dots"):
         regions = await get_regions()
 
-    if not regions:
-        console.print("[yellow]No regions available[/yellow]")
+    # Before the empty-result return: an empty set must still emit a
+    # well-formed JSON payload rather than zero bytes on stdout.
+    if console.json_output:
+        console.output_json({"regions": regions or []})
         return
 
-    if console.json_output:
-        console.output_json({"regions": regions})
+    if not regions:
+        console.print("[yellow]No regions available[/yellow]")
         return
 
     rows = [(region["code"], region["display_name"]) for region in regions]

--- a/src/pipecatcloud/cli/commands/secrets.py
+++ b/src/pipecatcloud/cli/commands/secrets.py
@@ -424,6 +424,10 @@ async def list_sets(
             status = data.get("status")
             error_message = data.get("errorMessage")
 
+            if console.json_output:
+                console.output_json(data)
+                return
+
             if not console.rich_output:
                 console.print_records(
                     ["Key"],
@@ -458,6 +462,10 @@ async def list_sets(
             if not filtered_sets or not len(filtered_sets):
                 console.error(f"No secret sets in namespace / organization [bold]'{org}'[/bold]")
                 raise typer.Exit(1)
+
+            if console.json_output:
+                console.output_json({"secretSets": filtered_sets})
+                return
 
             if not console.rich_output:
                 console.print_records(

--- a/src/pipecatcloud/cli/commands/secrets.py
+++ b/src/pipecatcloud/cli/commands/secrets.py
@@ -52,17 +52,17 @@ def validate_secrets(secrets: dict):
             console.print(
                 "[red]Error: Secrets must be provided as key-value pairs. Please reference --help for more information.[/red]"
             )
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         if len(key) > 64:
             console.print("[red]Error: Secret names must not exceed 64 characters in length.[/red]")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         if not valid_name_pattern.match(key):
             console.print(
                 "[red]Error: Secret names must contain only alphanumeric characters, underscores, and hyphens.[/red]"
             )
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
 
 def validate_secret_name(name: str):
@@ -111,17 +111,17 @@ async def create_set(
         console.print(
             "[red]Secret set name must only contain characters, numbers and hyphens.[/red]"
         )
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     if not secrets and not from_file:
         console.print(
             "[red]Command requires either passed key-values or relative file path. See --help for more information.[/red]"
         )
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     if secrets and from_file:
         console.print("[red]Cannot pass key-value pairs with --file option")
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     secrets_dict = {}
     org = organization or config.get("org")
@@ -130,7 +130,7 @@ async def create_set(
     if from_file:
         if not os.path.exists(from_file):
             console.print(f"[red]Error: File '{from_file}' does not exist.[/red]")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         try:
             with open(from_file) as f:
@@ -143,7 +143,7 @@ async def create_set(
                         console.print(
                             f"[red]Error: Invalid line format in {from_file}. Each line must be a key-value pair using '=' separator.[/red]"
                         )
-                        return typer.Exit(1)
+                        raise typer.Exit(1)
 
                     key, value = line.split("=", 1)
                     key = key.strip()
@@ -154,16 +154,18 @@ async def create_set(
 
                     if not key or not value:
                         console.error(f"Error: Empty key or value found in {from_file}")
-                        return typer.Exit(1)
+                        raise typer.Exit(1)
 
                     secrets_dict[key] = value
 
             if not secrets_dict:
                 console.error(f"Error: No valid secrets found in {from_file}")
-                return typer.Exit(1)
+                raise typer.Exit(1)
+        except typer.Exit:
+            raise
         except Exception as e:
             console.error(f"Error reading file '{from_file}': {str(e)}")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     else:
         for secret in secrets:
@@ -171,7 +173,7 @@ async def create_set(
                 console.error(
                     "Error: Secrets must be provided as key-value pairs using '=' separator. Example: KEY=value"
                 )
-                return typer.Exit(1)
+                raise typer.Exit(1)
 
             key, value = secret.split("=", 1)
             key = key.strip()
@@ -185,7 +187,7 @@ async def create_set(
                 console.print(
                     "[red]Error: Both key and value must be provided for each secret.[/red]"
                 )
-                return typer.Exit(1)
+                raise typer.Exit(1)
 
             secrets_dict[key] = value
 
@@ -200,7 +202,7 @@ async def create_set(
         console.print(
             f"[red]Invalid region '{region}'. Valid regions are: {', '.join(valid_regions)}[/red]"
         )
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     if not skip_confirm:
         table = Table(
@@ -219,7 +221,7 @@ async def create_set(
             # Fetch org's default region to show user what will be used
             props, error = await API.properties(org)
             if error:
-                return typer.Exit()
+                raise typer.Exit(1)
             console.print(
                 f"[bold white]Region:[/bold white] {props['defaultRegion']} [dim](organization default)[/dim]\n"
             )
@@ -235,7 +237,7 @@ async def create_set(
             "Would you like to proceed with these secrets?"
         ).ask_async()
         if not looks_good:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     # Confirm if we are sure we want to create a new secret set (if one doesn't already exist)
     existing_set = None
@@ -246,7 +248,7 @@ async def create_set(
         data, error = await API.secrets_list(org=org, secret_set=name)
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
         if data and len(data):
             existing_set = data
@@ -262,7 +264,7 @@ async def create_set(
             ).ask_async()
             if not create:
                 console.print("[bold red]Secret set creation cancelled[/bold red]")
-                return typer.Exit(1)
+                raise typer.Exit(1)
 
     used_region = None
     with console.status(
@@ -283,7 +285,7 @@ async def create_set(
             )
 
             if error:
-                return typer.Exit()
+                raise typer.Exit(1)
 
             # Capture the region that was used (from API response)
             if data and "region" in data:
@@ -329,7 +331,7 @@ async def unset(
         console.error(
             "Error: Secret set name and secret name must be provided. Please reference --help for more information."
         )
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     # Confirm to proceed
     if not skip_confirm:
@@ -338,7 +340,7 @@ async def unset(
         ).ask_async()
         if not confirm:
             console.error("Secret key unset cancelled")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     with console.status(
         f"[dim]Deleting secret [bold]'{secret_key}'[/bold] from secret set [bold]'{name}'[/bold][/dim]",
@@ -348,10 +350,10 @@ async def unset(
 
         if not data:
             console.error(f"Key not found in set '{name}'")
-            return typer.Exit()
+            raise typer.Exit(1)
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
     console.success(
         f"Secret [bold green]'{secret_key}'[/bold green] deleted successfully from secret set [bold green]'{name}'[/bold green]"
@@ -388,7 +390,7 @@ async def list_sets(
         console.print(
             f"[red]Invalid region '{region}'. Valid regions are: {', '.join(valid_regions)}[/red]"
         )
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     logger.debug(f"Secret set name to lookup: {name}")
 
@@ -403,7 +405,7 @@ async def list_sets(
                 console.error("Unable to lookup image pull secrets")
             else:
                 API.print_error()
-            return typer.Exit()
+            raise typer.Exit(1)
 
         if not data or not len(data):
             if name:
@@ -412,7 +414,7 @@ async def list_sets(
                 )
             else:
                 console.error(f"No secrets sets for namespace / organization [bold]'{org}'[/bold]")
-            return typer.Exit()
+            raise typer.Exit(1)
 
         if name:
             secrets = data.get("secrets") or []
@@ -442,7 +444,7 @@ async def list_sets(
 
             if not filtered_sets or not len(filtered_sets):
                 console.error(f"No secret sets in namespace / organization [bold]'{org}'[/bold]")
-                return typer.Exit()
+                raise typer.Exit(1)
 
             table = Table(
                 show_header=True,
@@ -505,17 +507,17 @@ async def delete(
         ).ask_async()
         if not confirm:
             console.print("[bold red]Secret deletion cancelled[/bold red]")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     with console.status(f"Deleting secret set [bold]'{name}'[/bold]", spinner="dots"):
         data, error = await API.secrets_delete_set(set_name=name, org=org)
 
         if not data:
             console.error(f"No set found with name '{name}")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     console.success(f"Secret set [bold green]'{name}'[/bold green] deleted successfully")
 
@@ -562,7 +564,7 @@ async def image_pull_secret(
         console.error(
             "Name and host must be provided. Please reference --help for more information."
         )
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     if not credentials:
         console.print(
@@ -575,7 +577,7 @@ async def image_pull_secret(
         ).ask_async()
         if not username or not password:
             console.print("[bold red]Image pull secret creation cancelled[/bold red]")
-            return typer.Exit(1)
+            raise typer.Exit(1)
         credentials = f"{username}:{password}"
 
     if base64encode:
@@ -588,7 +590,7 @@ async def image_pull_secret(
         console.print(
             f"[red]Invalid region '{region}'. Valid regions are: {', '.join(valid_regions)}[/red]"
         )
-        return typer.Exit(1)
+        raise typer.Exit(1)
 
     # Check if secret already exists
     existing_secret = None
@@ -598,7 +600,7 @@ async def image_pull_secret(
         data, error = await API.secrets_list(org=org)
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
         if data:
             existing_secret = next(
@@ -611,7 +613,7 @@ async def image_pull_secret(
         ).ask_async()
         if not confirm:
             console.print("[bold red]Update cancelled[/bold red]")
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     used_region = None
     with console.status(
@@ -626,7 +628,7 @@ async def image_pull_secret(
         )
 
         if error:
-            return typer.Exit()
+            raise typer.Exit(1)
 
         # Capture the region that was used (from API response)
         if data and "region" in data:

--- a/src/pipecatcloud/cli/commands/secrets.py
+++ b/src/pipecatcloud/cli/commands/secrets.py
@@ -233,6 +233,7 @@ async def create_set(
             )
         )
         # Confirm our secrets
+        console.require_interactive("--skip")
         looks_good = await questionary.confirm(
             "Would you like to proceed with these secrets?"
         ).ask_async()
@@ -259,6 +260,7 @@ async def create_set(
         overlapping_secrets = existing_secret_names.intersection(secrets_dict.keys())
 
         if overlapping_secrets and not skip_confirm:
+            console.require_interactive("--skip")
             create = await questionary.confirm(
                 f"The following secret(s) already exist in {name} will be overwritten: {', '.join(overlapping_secrets)}. Would you like to continue?"
             ).ask_async()
@@ -335,6 +337,7 @@ async def unset(
 
     # Confirm to proceed
     if not skip_confirm:
+        console.require_interactive("--skip")
         confirm = await questionary.confirm(
             f"Are you sure you want to unset secret with key '{secret_key}' from set '{name}'?"
         ).ask_async()
@@ -421,6 +424,16 @@ async def list_sets(
             status = data.get("status")
             error_message = data.get("errorMessage")
 
+            if not console.rich_output:
+                console.print_records(
+                    ["Key"],
+                    [(s["fieldName"],) for s in secrets],
+                    title=f"Secret keys for set {name} (status: {status or 'unknown'})",
+                )
+                if status == "failed" and error_message:
+                    console.print(f"[red]{error_message}[/red]")
+                return
+
             table = Table(border_style="dim", show_header=False, show_edge=True, show_lines=True)
             table.add_column(name, style="white")
             for s in secrets:
@@ -445,6 +458,24 @@ async def list_sets(
             if not filtered_sets or not len(filtered_sets):
                 console.error(f"No secret sets in namespace / organization [bold]'{org}'[/bold]")
                 raise typer.Exit(1)
+
+            if not console.rich_output:
+                console.print_records(
+                    ["Secret Set Name", "Region", "Status", "Type"],
+                    [
+                        (
+                            secret_set["name"],
+                            secret_set["region"],
+                            secret_set.get("status") or "unknown",
+                            "Image Pull Secret"
+                            if secret_set["type"] == "imagePullSecret"
+                            else "Secret Set",
+                        )
+                        for secret_set in filtered_sets
+                    ],
+                    title=f"Secret sets for {org}",
+                )
+                return
 
             table = Table(
                 show_header=True,
@@ -502,6 +533,7 @@ async def delete(
 
     # Confirm to proceed
     if not skip_confirm:
+        console.require_interactive("--skip")
         confirm = await questionary.confirm(
             f"Are you sure you want to delete secret set '{name}'?"
         ).ask_async()
@@ -571,6 +603,7 @@ async def image_pull_secret(
             "[cyan]For more information about image pull secrets, see: "
             "https://docs.pipecat.ai/pipecat-cloud/fundamentals/secrets#image-pull-secrets[/cyan]\n"
         )
+        console.require_interactive("the credentials argument")
         username = await questionary.text(f"Username for image repository '{host}'").ask_async()
         password = await questionary.password(
             f"Access token for image repository '{host}'"
@@ -608,6 +641,7 @@ async def image_pull_secret(
             )
 
     if existing_secret and not skip_confirm:
+        console.require_interactive("--skip")
         confirm = await questionary.confirm(
             f"Image pull secret '{name}' already exists. Update it?"
         ).ask_async()

--- a/src/pipecatcloud/cli/commands/spend_limit.py
+++ b/src/pipecatcloud/cli/commands/spend_limit.py
@@ -13,7 +13,7 @@ from rich.table import Table
 
 from pipecatcloud._utils.async_utils import synchronizer
 from pipecatcloud._utils.auth_utils import requires_login
-from pipecatcloud._utils.console_utils import console, format_cents, format_timestamp
+from pipecatcloud._utils.console_utils import OutputMode, console, format_cents, format_timestamp
 from pipecatcloud.cli.api import API
 from pipecatcloud.cli.config import config
 
@@ -113,21 +113,22 @@ async def show(
     output_json: bool = typer.Option(
         False,
         "--json",
-        help="Print raw JSON instead of a formatted table",
+        help="Deprecated alias for the global --output json mode",
     ),
 ):
     org = organization or config.get("org")
 
     if output_json:
-        # Bubble errors so we don't print a rich panel before/instead of the JSON.
+        # Predates the global --output mechanism; kept as an alias.
+        console.set_output_mode(OutputMode.json)
+
+    if console.json_output:
+        # Bubble errors so the error object is the only thing on stdout.
         data, error = await API.bubble_error().spend_limit_get(org)
         if error:
-            console.print_json(data={"error": error})
+            console.output_json({"error": error})
             raise typer.Exit(1)
-        if data is None:
-            console.print_json(data={})
-            return
-        console.print_json(data=data)
+        console.output_json(data if data is not None else {})
         return
 
     with console.status(
@@ -211,6 +212,10 @@ async def set_limit(
         if error:
             raise typer.Exit(1)
 
+    if console.json_output:
+        console.output_json(data or {})
+        return
+
     console.success(
         f"Spend limit for [bold]'{org}'[/bold] set to "
         f"[bold green]{format_cents(new_cents)}[/bold green]."
@@ -256,6 +261,10 @@ async def clear(
 
         if error:
             raise typer.Exit(1)
+
+    if console.json_output:
+        console.output_json(data or {})
+        return
 
     console.success(f"Spend limit for [bold]'{org}'[/bold] cleared.")
     if data:

--- a/src/pipecatcloud/cli/commands/spend_limit.py
+++ b/src/pipecatcloud/cli/commands/spend_limit.py
@@ -183,9 +183,12 @@ async def set_limit(
 
     current_spend = (current or {}).get("currentSpendCents") or 0
 
+    # Guard inside the prompt branches, not above them: most `set` invocations
+    # (raising or setting a fresh limit) show no prompt at all, and those must
+    # keep working non-interactively without --yes.
     if not yes:
-        console.require_interactive("--yes")
         if new_cents == 0:
+            console.require_interactive("--yes")
             confirm = await questionary.confirm(
                 "Setting the limit to $0.00 blocks all new sessions until you raise it. Continue?",
                 default=False,
@@ -194,6 +197,7 @@ async def set_limit(
                 console.cancel()
                 raise typer.Exit(1)
         elif current_spend > new_cents:
+            console.require_interactive("--yes")
             confirm = await questionary.confirm(
                 f"Current spend ({format_cents(current_spend)}) exceeds the new limit "
                 f"({format_cents(new_cents)}). New sessions will be blocked. Continue?",

--- a/src/pipecatcloud/cli/commands/spend_limit.py
+++ b/src/pipecatcloud/cli/commands/spend_limit.py
@@ -183,6 +183,7 @@ async def set_limit(
     current_spend = (current or {}).get("currentSpendCents") or 0
 
     if not yes:
+        console.require_interactive("--yes")
         if new_cents == 0:
             confirm = await questionary.confirm(
                 "Setting the limit to $0.00 blocks all new sessions until you raise it. Continue?",
@@ -238,6 +239,7 @@ async def clear(
     org = organization or config.get("org")
 
     if not yes:
+        console.require_interactive("--yes")
         confirm = await questionary.confirm(
             f"Remove the spend limit for '{org}'? New sessions will not be capped.",
             default=False,

--- a/src/pipecatcloud/cli/commands/spend_limit.py
+++ b/src/pipecatcloud/cli/commands/spend_limit.py
@@ -123,7 +123,7 @@ async def show(
         data, error = await API.bubble_error().spend_limit_get(org)
         if error:
             console.print_json(data={"error": error})
-            return typer.Exit(1)
+            raise typer.Exit(1)
         if data is None:
             console.print_json(data={})
             return
@@ -137,7 +137,7 @@ async def show(
         data, error = await API.spend_limit_get(org)
 
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     if data is None:
         console.print("[dim]No spend-limit data available for this organization.[/dim]")
@@ -178,7 +178,7 @@ async def set_limit(
     ):
         current, error = await API.spend_limit_get(org)
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     current_spend = (current or {}).get("currentSpendCents") or 0
 
@@ -190,7 +190,7 @@ async def set_limit(
             ).ask_async()
             if not confirm:
                 console.cancel()
-                return typer.Exit(1)
+                raise typer.Exit(1)
         elif current_spend > new_cents:
             confirm = await questionary.confirm(
                 f"Current spend ({format_cents(current_spend)}) exceeds the new limit "
@@ -199,7 +199,7 @@ async def set_limit(
             ).ask_async()
             if not confirm:
                 console.cancel()
-                return typer.Exit(1)
+                raise typer.Exit(1)
 
     with console.status(
         f"[dim]Setting spend limit to {format_cents(new_cents)}[/dim]",
@@ -208,7 +208,7 @@ async def set_limit(
         data, error = await API.spend_limit_update(org, new_cents)
 
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     console.success(
         f"Spend limit for [bold]'{org}'[/bold] set to "
@@ -244,7 +244,7 @@ async def clear(
         ).ask_async()
         if not confirm:
             console.cancel()
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     with console.status(
         f"[dim]Clearing spend limit for organization: [bold]'{org}'[/bold][/dim]",
@@ -253,7 +253,7 @@ async def clear(
         data, error = await API.spend_limit_update(org, None)
 
         if error:
-            return typer.Exit(1)
+            raise typer.Exit(1)
 
     console.success(f"Spend limit for [bold]'{org}'[/bold] cleared.")
     if data:

--- a/src/pipecatcloud/cli/config.py
+++ b/src/pipecatcloud/cli/config.py
@@ -171,6 +171,8 @@ _CLI_SETTINGS = {
     "default_public_key": _Setting(),
     "default_public_key_name": _Setting(),
     "cli_log_level": _Setting("INFO"),
+    # Output mode (rich/plain/json); also settable via PIPECAT_OUTPUT
+    "output": _Setting(),
 }
 
 

--- a/src/pipecatcloud/cli/entry_point.py
+++ b/src/pipecatcloud/cli/entry_point.py
@@ -9,7 +9,7 @@ import sys
 import typer
 from loguru import logger
 
-from pipecatcloud._utils.console_utils import console
+from pipecatcloud._utils.console_utils import OutputMode, console
 from pipecatcloud.cli.commands.agent import agent_cli
 from pipecatcloud.cli.commands.auth import auth_cli
 from pipecatcloud.cli.commands.build import build_cli
@@ -89,8 +89,24 @@ def cli(
         callback=show_config_callback,
         help="Show CLI internal configuration (credentials redacted)",
     ),
+    output: OutputMode | None = typer.Option(
+        None,
+        "--output",
+        help="Output mode: rich (interactive), plain (line-oriented, no boxes or "
+        "truncation), json (machine-readable on stdout). Defaults to rich on a "
+        "terminal and plain otherwise; can also be set via PIPECAT_OUTPUT.",
+    ),
 ):
-    pass
+    # Resolution order: --output flag > PIPECAT_OUTPUT env / config file >
+    # auto-detect (rich on a terminal, plain when piped).
+    resolved = output or config.get("output")
+    if resolved is not None:
+        try:
+            console.set_output_mode(OutputMode(resolved))
+        except ValueError:
+            valid = ", ".join(m.value for m in OutputMode)
+            console.error(f"Invalid output mode '{resolved}'. Valid modes are: {valid}")
+            raise typer.Exit(2) from None
 
 
 create_deploy_command(entrypoint_cli_typer)

--- a/src/pipecatcloud/cli/entry_point.py
+++ b/src/pipecatcloud/cli/entry_point.py
@@ -94,7 +94,8 @@ def cli(
         "--output",
         help="Output mode: rich (interactive), plain (line-oriented, no boxes or "
         "truncation), json (machine-readable on stdout). Defaults to rich on a "
-        "terminal and plain otherwise; can also be set via PIPECAT_OUTPUT.",
+        "terminal and plain otherwise; can also be set via PIPECAT_OUTPUT. "
+        "Place before the subcommand: pipecat cloud --output json agent list.",
     ),
 ):
     # Resolution order: --output flag > PIPECAT_OUTPUT env / config file >

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,21 @@ _tmp = tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w")
 _tmp.write('token = "test-token"\norg = "test-org"\n')
 _tmp.close()
 os.environ["PIPECAT_CONFIG_PATH"] = _tmp.name
+
+import pytest  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_console_output_mode():
+    """The output mode mutates the console singleton (e.g. `spend-limit show
+    --json` or the global --output callback); restore it so one test's mode
+    can't leak into the next. Save the private `_file` (normally None =
+    resolve sys.stdout dynamically), not the `file` property — pinning the
+    resolved object back would bypass CliRunner capture in later tests."""
+    from pipecatcloud._utils.console_utils import console
+
+    explicit = console._explicit_output_mode
+    file = console._file
+    yield
+    console._explicit_output_mode = explicit
+    console._file = file

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -44,16 +44,14 @@ class TestAgentSessionsCommand:
         # Arrange: _agent_sessions raises exception (API error)
         mock_api.side_effect = Exception("Agent not found")
 
-        # Act: Call with API error
-        result = sessions(
-            deploy_config=None,
-            agent_name="nonexistent-agent",
-            session_id=None,
-            organization=TEST_ORG,
-        )
-
-        # Assert: Should return typer.Exit on error
-        assert isinstance(result, type(typer.Exit()))
+        # Act & Assert: Should raise typer.Exit on error
+        with pytest.raises(typer.Exit):
+            sessions(
+                deploy_config=None,
+                agent_name="nonexistent-agent",
+                session_id=None,
+                organization=TEST_ORG,
+            )
 
     @patch("pipecatcloud._utils.deploy_utils.load_deploy_config_file")
     def test_handles_missing_agent_name_gracefully(self, mock_load_config):
@@ -61,14 +59,12 @@ class TestAgentSessionsCommand:
         # Arrange: Mock the config loader to return None (no config file)
         mock_load_config.return_value = None
 
-        # Act: Call with no agent name from either source
-        result = sessions(
-            deploy_config=None,  # No deploy config
-            agent_name=None,  # No agent name argument
-            session_id=None,
-            organization=TEST_ORG,
-        )
-
-        # Assert: Should return typer.Exit(1) with error message
-        assert isinstance(result, type(typer.Exit()))
-        assert result.exit_code == 1
+        # Act & Assert: Should raise typer.Exit(1) with error message
+        with pytest.raises(typer.Exit) as exc_info:
+            sessions(
+                deploy_config=None,  # No deploy config
+                agent_name=None,  # No agent name argument
+                session_id=None,
+                organization=TEST_ORG,
+            )
+        assert exc_info.value.exit_code == 1

--- a/tests/test_agent_stop.py
+++ b/tests/test_agent_stop.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 import typer
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -27,10 +28,12 @@ class TestAgentStopCommand:
     def test_stop_respects_force_flag(self):
         """Verify force flag skips confirmation when set to True."""
         with (
+            patch("pipecatcloud.cli.commands.agent.API") as mock_api,
             patch("pipecatcloud.cli.commands.agent.config") as mock_config,
             patch("pipecatcloud.cli.commands.agent.questionary") as mock_questionary,
             patch("pipecatcloud.cli.commands.agent.DeployConfigParams") as mock_params,
         ):
+            mock_api.agent_session_terminate = AsyncMock(return_value=({}, None))
             mock_config.get.return_value = TEST_ORG
             mock_params.return_value = MagicMock(agent_name=TEST_AGENT)
             # Mock questionary - should NOT be called when force=True
@@ -52,10 +55,12 @@ class TestAgentStopCommand:
     def test_stop_shows_confirmation_without_force(self):
         """Verify confirmation prompt is shown when force is False."""
         with (
+            patch("pipecatcloud.cli.commands.agent.API") as mock_api,
             patch("pipecatcloud.cli.commands.agent.config") as mock_config,
             patch("pipecatcloud.cli.commands.agent.questionary") as mock_questionary,
             patch("pipecatcloud.cli.commands.agent.DeployConfigParams") as mock_params,
         ):
+            mock_api.agent_session_terminate = AsyncMock(return_value=({}, None))
             mock_config.get.return_value = TEST_ORG
             mock_params.return_value = MagicMock(agent_name=TEST_AGENT)
             # User agrees to the confirmation
@@ -87,18 +92,17 @@ class TestAgentStopCommand:
             # User rejects the confirmation
             mock_questionary.confirm.return_value.ask_async = AsyncMock(return_value=False)
 
-            # Act
-            result = stop(
-                deploy_config=None,
-                agent_name=TEST_AGENT,
-                session_id=TEST_SESSION_ID,
-                organization=TEST_ORG,
-                force=False,
-            )
-
-            # Assert
+            # Act & Assert
             # Should exit with code 1 (abort)
-            assert isinstance(result, typer.Exit)
-            assert result.exit_code == 1
+            with pytest.raises(typer.Exit) as exc_info:
+                stop(
+                    deploy_config=None,
+                    agent_name=TEST_AGENT,
+                    session_id=TEST_SESSION_ID,
+                    organization=TEST_ORG,
+                    force=False,
+                )
+
+            assert exc_info.value.exit_code == 1
             # Should display abort message
             mock_console.print.assert_any_call("[bold]Aborting stop request[/bold]")

--- a/tests/test_agent_stop.py
+++ b/tests/test_agent_stop.py
@@ -59,6 +59,7 @@ class TestAgentStopCommand:
             patch("pipecatcloud.cli.commands.agent.config") as mock_config,
             patch("pipecatcloud.cli.commands.agent.questionary") as mock_questionary,
             patch("pipecatcloud.cli.commands.agent.DeployConfigParams") as mock_params,
+            patch("pipecatcloud._utils.console_utils.stdin_is_interactive", return_value=True),
         ):
             mock_api.agent_session_terminate = AsyncMock(return_value=({}, None))
             mock_config.get.return_value = TEST_ORG

--- a/tests/test_build_id_display.py
+++ b/tests/test_build_id_display.py
@@ -1,0 +1,58 @@
+"""Tests for build-ID surfacing when the image URI is redacted (PCC-1064).
+
+Cloud-built deployments have manifest.spec.image stripped by the API
+(internal ECR URI); the CLI used to render "Image: N/A". The build ID is
+the customer-facing artifact reference and must be shown instead.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+# Import from source, not installed package
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from pipecatcloud.cli.commands.agent import _image_display
+from pipecatcloud.cli.entry_point import entrypoint_cli_typer
+
+runner = CliRunner()
+
+BUILD_ID = "b-4bb223c4-9f31-44f5-9b3c-c6b8ea9c3a01"
+
+
+class TestImageDisplay:
+    def test_image_present_wins(self):
+        deployment = {
+            "buildId": BUILD_ID,
+            "manifest": {"spec": {"image": "docker.io/me/bot:1"}},
+        }
+        assert _image_display(deployment) == ("Image", "docker.io/me/bot:1")
+
+    def test_redacted_image_falls_back_to_build_id(self):
+        deployment = {"buildId": BUILD_ID, "manifest": {"spec": {}}}
+        assert _image_display(deployment) == ("Build", BUILD_ID)
+
+    def test_neither_stays_na(self):
+        assert _image_display({}) == ("Image", "N/A")
+
+
+class TestAgentStatusBuildId:
+    def test_status_shows_build_id_for_cloud_build(self):
+        payload = {
+            "ready": True,
+            "activeSessionCount": 0,
+            "deployment": {"buildId": BUILD_ID, "manifest": {"spec": {}}},
+            "activeDeploymentId": "dep-1",
+            "createdAt": "2026-01-01T00:00:00.000Z",
+            "updatedAt": "2026-01-01T00:00:00.000Z",
+            "autoScaling": {"minReplicas": 0, "maxReplicas": 5},
+            "errors": [],
+        }
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            mock_api.agent = AsyncMock(return_value=(payload, None))
+            result = runner.invoke(entrypoint_cli_typer, ["agent", "status", "some-agent"])
+        assert result.exit_code == 0
+        assert f"Build: {BUILD_ID}" in result.output
+        assert "Image: N/A" not in result.output

--- a/tests/test_deploy_image_pull_secret.py
+++ b/tests/test_deploy_image_pull_secret.py
@@ -60,8 +60,10 @@ async def test_matching_image_pull_secret_passes_guard(deploy_mocks):
         )
     )
 
-    # Act
-    await _deploy(_make_params(), "test-org", force=True)
+    # Act: the mocked API.deploy error halts the flow right after the guard,
+    # which now surfaces as a raised typer.Exit.
+    with pytest.raises(typer.Exit):
+        await _deploy(_make_params(), "test-org", force=True)
 
     # Assert: guard passed, so deployment was attempted
     deploy_mocks.deploy.assert_awaited_once()
@@ -78,11 +80,9 @@ async def test_same_name_wrong_type_is_rejected(deploy_mocks):
         )
     )
 
-    # Act
-    result = await _deploy(_make_params(), "test-org", force=True)
-
-    # Assert: aborted before attempting deployment
-    assert isinstance(result, typer.Exit)
+    # Act & Assert: aborted before attempting deployment
+    with pytest.raises(typer.Exit):
+        await _deploy(_make_params(), "test-org", force=True)
     deploy_mocks.deploy.assert_not_awaited()
 
 
@@ -92,11 +92,9 @@ async def test_missing_secret_is_rejected(deploy_mocks):
     # Arrange
     deploy_mocks.secrets_list = AsyncMock(return_value=([], None))
 
-    # Act
-    result = await _deploy(_make_params(), "test-org", force=True)
-
-    # Assert
-    assert isinstance(result, typer.Exit)
+    # Act & Assert
+    with pytest.raises(typer.Exit):
+        await _deploy(_make_params(), "test-org", force=True)
     deploy_mocks.deploy.assert_not_awaited()
 
 
@@ -106,9 +104,7 @@ async def test_secrets_list_error_aborts(deploy_mocks):
     # Arrange
     deploy_mocks.secrets_list = AsyncMock(return_value=(None, {"code": "500"}))
 
-    # Act
-    result = await _deploy(_make_params(), "test-org", force=True)
-
-    # Assert
-    assert isinstance(result, typer.Exit)
+    # Act & Assert
+    with pytest.raises(typer.Exit):
+        await _deploy(_make_params(), "test-org", force=True)
     deploy_mocks.deploy.assert_not_awaited()

--- a/tests/test_deploy_image_pull_secret.py
+++ b/tests/test_deploy_image_pull_secret.py
@@ -41,7 +41,6 @@ def deploy_mocks():
     """
     with (
         patch("pipecatcloud.cli.commands.deploy.API") as mock_api,
-        patch("pipecatcloud.cli.commands.deploy.Live"),
         patch("pipecatcloud.cli.commands.deploy.console"),
     ):
         mock_api.agent = AsyncMock(return_value=(None, None))

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -1,0 +1,111 @@
+"""End-to-end process exit-code tests (PCC-1064).
+
+The CLI used to ``return typer.Exit(1)`` from command bodies. Typer discards a
+command's return value, so every failure path exited 0 — CI wrappers could not
+detect that a command failed at all. These tests invoke the real Typer app via
+CliRunner and assert the actual exit code, which the old suite never did.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+# Import from source, not installed package
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from pipecatcloud.cli.entry_point import entrypoint_cli_typer
+
+runner = CliRunner()
+
+TEST_AGENT = "some-agent"
+
+# Minimal healthy payload for `agent status` rendering. autoScaling is included
+# because the render path references scaling_panel only when it is present.
+AGENT_STATUS_READY = {
+    "ready": True,
+    "activeSessionCount": 0,
+    "deployment": {"manifest": {"spec": {"image": "registry.example.com/img:1"}}},
+    "activeDeploymentId": "dep-1",
+    "createdAt": "2026-01-01T00:00:00.000Z",
+    "updatedAt": "2026-01-01T00:00:00.000Z",
+    "autoScaling": {"minReplicas": 0, "maxReplicas": 5},
+    "errors": [],
+}
+
+
+class TestProcessExitCodes:
+    def test_not_logged_in_exits_nonzero(self):
+        """The ticket's headline repro: no token must not exit 0."""
+        with patch("pipecatcloud._utils.auth_utils.config") as mock_config:
+            mock_config.get.return_value = None
+            result = runner.invoke(entrypoint_cli_typer, ["agent", "status", TEST_AGENT])
+        assert result.exit_code == 1
+
+    def test_agent_status_api_error_exits_nonzero(self):
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            mock_api.agent = AsyncMock(return_value=(None, {"code": "500", "error": "boom"}))
+            result = runner.invoke(entrypoint_cli_typer, ["agent", "status", TEST_AGENT])
+        assert result.exit_code == 1
+
+    def test_agent_status_missing_agent_exits_nonzero(self):
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            mock_api.agent = AsyncMock(return_value=(None, None))
+            result = runner.invoke(entrypoint_cli_typer, ["agent", "status", TEST_AGENT])
+        assert result.exit_code == 1
+
+    def test_agent_status_success_exits_zero(self):
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            mock_api.agent = AsyncMock(return_value=(AGENT_STATUS_READY, None))
+            result = runner.invoke(entrypoint_cli_typer, ["agent", "status", TEST_AGENT])
+        assert result.exit_code == 0
+
+    def test_agent_list_api_error_exits_nonzero(self):
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            mock_api.agents = AsyncMock(return_value=(None, {"code": "500", "error": "boom"}))
+            result = runner.invoke(entrypoint_cli_typer, ["agent", "list"])
+        assert result.exit_code == 1
+
+    def test_deploy_without_agent_name_exits_nonzero(self):
+        """No agent name from args or config file must fail, not exit 0."""
+        with patch("pipecatcloud._utils.deploy_utils.load_deploy_config_file", return_value=None):
+            result = runner.invoke(entrypoint_cli_typer, ["deploy"])
+        assert result.exit_code == 1
+
+    def test_secrets_set_invalid_name_exits_nonzero(self):
+        result = runner.invoke(
+            entrypoint_cli_typer, ["secrets", "set", "invalid_name!", "KEY=value"]
+        )
+        assert result.exit_code == 1
+
+    def test_spend_limit_json_api_error_exits_nonzero(self):
+        with patch("pipecatcloud.cli.commands.spend_limit.API") as mock_api:
+            mock_api.bubble_error.return_value.spend_limit_get = AsyncMock(
+                return_value=(None, {"code": "500", "error": "boom"})
+            )
+            result = runner.invoke(entrypoint_cli_typer, ["spend-limit", "show", "--json"])
+        assert result.exit_code == 1
+
+
+def test_no_discarded_typer_exit_in_source():
+    """Regression guard: `return typer.Exit(...)` never fires — Typer discards
+    return values — and a bare `typer.Exit(...)` statement is constructed and
+    thrown away. Both silently exit 0. Exits must be raised."""
+    import re
+
+    discarded_statement = re.compile(r"^\s+typer\.(Exit|Abort)\(")
+    src_root = Path(__file__).parent.parent / "src"
+    offenders = []
+    for py_file in src_root.rglob("*.py"):
+        for lineno, line in enumerate(py_file.read_text().splitlines(), start=1):
+            if (
+                "return typer.Exit" in line
+                or "return typer.Abort" in line
+                or discarded_statement.match(line)
+            ):
+                offenders.append(f"{py_file.relative_to(src_root)}:{lineno}")
+    assert not offenders, (
+        "Found discarded typer.Exit/Abort (must be raised, not returned or dropped): "
+        + ", ".join(offenders)
+    )

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -1,0 +1,124 @@
+"""Tests for the machine-readable JSON output mode (PCC-1064).
+
+Contract: with --output json, stdout carries exactly one JSON object; all
+human-facing output goes to stderr; failures exit non-zero, with API errors
+also emitted as {"error": ...} on stdout.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+# Import from source, not installed package
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from pipecatcloud.cli.entry_point import entrypoint_cli_typer
+
+runner = CliRunner()
+
+AGENT_LIST_PAYLOAD = [
+    {
+        "name": "site-survey",
+        "region": "us-east-1",
+        "id": "4bb223c4-9f31-44f5-9b3c-c6b8ea9c3a01",
+        "activeDeploymentId": "7c9d1e55-8a76-4a2b-b6ce-2f0d4a9be777",
+        "createdAt": "2026-07-01T00:00:00.000Z",
+        "updatedAt": "2026-07-20T00:00:00.000Z",
+    }
+]
+
+AGENT_STATUS_PAYLOAD = {
+    "ready": True,
+    "activeSessionCount": 2,
+    "deployment": {"manifest": {"spec": {"image": "registry.example.com/img:1"}}},
+    "activeDeploymentId": "dep-1",
+    "createdAt": "2026-01-01T00:00:00.000Z",
+    "updatedAt": "2026-01-01T00:00:00.000Z",
+    "autoScaling": {"minReplicas": 0, "maxReplicas": 5},
+    "errors": [],
+}
+
+
+class TestJsonMode:
+    def test_agent_list_emits_single_json_object_on_stdout(self):
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            mock_api.agents = AsyncMock(return_value=(AGENT_LIST_PAYLOAD, None))
+            result = runner.invoke(entrypoint_cli_typer, ["--output", "json", "agent", "list"])
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload == {"agents": AGENT_LIST_PAYLOAD}
+
+    def test_agent_status_round_trips_payload(self):
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            mock_api.agent = AsyncMock(return_value=(AGENT_STATUS_PAYLOAD, None))
+            result = runner.invoke(
+                entrypoint_cli_typer, ["--output", "json", "agent", "status", "site-survey"]
+            )
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == AGENT_STATUS_PAYLOAD
+
+    def test_human_chatter_goes_to_stderr(self):
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            mock_api.agents = AsyncMock(return_value=(AGENT_LIST_PAYLOAD, None))
+            result = runner.invoke(entrypoint_cli_typer, ["--output", "json", "agent", "list"])
+        # The status line ("Fetching agents...") must not pollute stdout
+        assert "Fetching agents" not in result.stdout
+        assert "Fetching agents" in result.stderr
+
+    def test_api_error_emits_error_object_and_exits_nonzero(self):
+        api_error = {"code": "500", "error": "boom"}
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            # The command sees (None, error); the real wrapper prints via
+            # API.print_error, which the mock replaces, so assert on the
+            # spend-limit path below for the stdout error object instead.
+            mock_api.agents = AsyncMock(return_value=(None, api_error))
+            result = runner.invoke(entrypoint_cli_typer, ["--output", "json", "agent", "list"])
+        assert result.exit_code == 1
+
+    def test_spend_limit_json_flag_is_alias_for_json_mode(self):
+        payload = {"limitCents": 5000, "currentSpendCents": 100}
+        with patch("pipecatcloud.cli.commands.spend_limit.API") as mock_api:
+            mock_api.bubble_error.return_value.spend_limit_get = AsyncMock(
+                return_value=(payload, None)
+            )
+            result = runner.invoke(entrypoint_cli_typer, ["spend-limit", "show", "--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == payload
+
+    def test_spend_limit_json_error_object_on_stdout(self):
+        api_error = {"code": "500", "error": "boom"}
+        with patch("pipecatcloud.cli.commands.spend_limit.API") as mock_api:
+            mock_api.bubble_error.return_value.spend_limit_get = AsyncMock(
+                return_value=(None, api_error)
+            )
+            result = runner.invoke(entrypoint_cli_typer, ["spend-limit", "show", "--json"])
+        assert result.exit_code == 1
+        assert json.loads(result.stdout) == {"error": api_error}
+
+    def test_print_error_emits_json_error_in_json_mode(self, capsys):
+        """The _API.print_error hook writes {"error": ...} to stdout in json mode."""
+        from pipecatcloud._utils.console_utils import OutputMode, console
+        from pipecatcloud.api import _API
+
+        console.set_output_mode(OutputMode.json)
+        api = _API(token="test-token", is_cli=True)
+        api.error = {"code": "429", "error": "rate limited"}
+        api.print_error()
+        captured = capsys.readouterr()
+        assert json.loads(captured.out) == {"error": {"code": "429", "error": "rate limited"}}
+        # Human rendering went to stderr
+        assert "rate limited" in captured.err
+
+    def test_regions_list_json(self):
+        regions = [{"code": "us-west-2", "display_name": "US West (Oregon)"}]
+        with patch(
+            "pipecatcloud.cli.commands.regions.get_regions",
+            new_callable=AsyncMock,
+            return_value=regions,
+        ):
+            result = runner.invoke(entrypoint_cli_typer, ["--output", "json", "regions", "list"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == {"regions": regions}

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -122,3 +122,105 @@ class TestJsonMode:
             result = runner.invoke(entrypoint_cli_typer, ["--output", "json", "regions", "list"])
         assert result.exit_code == 0
         assert json.loads(result.stdout) == {"regions": regions}
+
+
+class TestJsonEmptyResults:
+    """Empty result sets must emit a well-formed JSON payload, not zero bytes.
+
+    The pre-existing empty-result early returns print to the console (stderr
+    in json mode); if the json branch sits below them, stdout is empty and
+    `jq` errors on the output of a command that exited 0.
+    """
+
+    def test_build_list_empty(self):
+        with patch("pipecatcloud.cli.commands.build.API") as mock_api:
+            mock_api.build_list = AsyncMock(return_value=({"builds": [], "total": 0}, None))
+            result = runner.invoke(entrypoint_cli_typer, ["--output", "json", "build", "list"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == {"builds": [], "total": 0}
+
+    def test_regions_list_empty(self):
+        with patch(
+            "pipecatcloud.cli.commands.regions.get_regions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = runner.invoke(entrypoint_cli_typer, ["--output", "json", "regions", "list"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == {"regions": []}
+
+    def test_properties_list_empty(self):
+        with patch("pipecatcloud.cli.commands.organizations.API") as mock_api:
+            mock_api.properties = AsyncMock(return_value=(None, None))
+            result = runner.invoke(
+                entrypoint_cli_typer,
+                ["--output", "json", "organizations", "properties", "list"],
+            )
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == {}
+
+    def test_properties_schema_empty(self):
+        with patch("pipecatcloud.cli.commands.organizations.API") as mock_api:
+            mock_api.properties_schema = AsyncMock(return_value=(None, None))
+            result = runner.invoke(
+                entrypoint_cli_typer,
+                ["--output", "json", "organizations", "properties", "schema"],
+            )
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == {}
+
+
+class TestWhoamiJson:
+    """whoami exercises the real _API wrapper, which is where double-emission
+    of {"error": ...} objects can occur (the wrapper reports errors itself)."""
+
+    @staticmethod
+    def _fake_base_request(responses: dict):
+        """Route _base_request by URL suffix; a suffix mapped to an Exception
+        sets self.error (as the real _base_request does) and raises."""
+
+        async def fake(self, method, url, **kwargs):
+            for suffix, value in responses.items():
+                if url.endswith(suffix):
+                    if isinstance(value, Exception):
+                        self.error = {"code": "500", "error": str(value)}
+                        raise value
+                    return value
+            raise AssertionError(f"unexpected URL in test: {url}")
+
+        return fake
+
+    def test_org_lookup_failure_emits_exactly_one_error_object(self):
+        from pipecatcloud.api import _API
+
+        fake = self._fake_base_request(
+            {
+                "/users": {"user": {"userId": "u1", "emails": []}},
+                "/organizations": RuntimeError("org lookup failed"),
+            }
+        )
+        with patch.object(_API, "_base_request", fake):
+            result = runner.invoke(entrypoint_cli_typer, ["--output", "json", "auth", "whoami"])
+        assert result.exit_code == 1
+        # json.loads fails if stdout contains two concatenated objects
+        assert json.loads(result.stdout) == {"error": {"code": "500", "error": "org lookup failed"}}
+
+    def test_nonfatal_daily_key_failure_keeps_stdout_clean(self):
+        from pipecatcloud.api import _API
+
+        fake = self._fake_base_request(
+            {
+                "/daily": RuntimeError("daily key unavailable"),
+                "/users": {"user": {"userId": "u1", "emails": []}},
+                "/organizations": {
+                    "organizations": [{"name": "test-org", "verboseName": "Test Org"}]
+                },
+            }
+        )
+        with patch.object(_API, "_base_request", fake):
+            result = runner.invoke(entrypoint_cli_typer, ["--output", "json", "auth", "whoami"])
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["organization"] == {"name": "test-org", "verbose_name": "Test Org"}
+        assert payload["dailyApiKey"] is None
+        assert "error" not in payload

--- a/tests/test_output_modes.py
+++ b/tests/test_output_modes.py
@@ -37,19 +37,8 @@ AGENT_LIST_PAYLOAD = [
 ]
 
 
-@pytest.fixture(autouse=True)
-def reset_console_mode():
-    """set_output_mode mutates the module singleton; restore it around tests.
-
-    Save the private ``_file`` (normally None = resolve sys.stdout dynamically),
-    not the ``file`` property: reading the property returns the *current*
-    stdout object, and pinning that back would bypass CliRunner's capture.
-    """
-    explicit = console._explicit_output_mode
-    file = console._file
-    yield
-    console._explicit_output_mode = explicit
-    console._file = file
+# Note: the autouse fixture restoring the console singleton's output mode
+# lives in conftest.py so it protects every test module.
 
 
 def make_console(**kwargs) -> tuple[PipecatConsole, StringIO]:

--- a/tests/test_output_modes.py
+++ b/tests/test_output_modes.py
@@ -1,0 +1,190 @@
+"""Tests for the non-interactive output modes (PCC-1064).
+
+Covers mode resolution (--output flag, PIPECAT_OUTPUT env, auto-detection),
+the plain-mode status sink that replaces silent Rich spinners in non-TTY,
+untruncated plain-mode listings, and the non-interactive confirmation guard.
+"""
+
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+# Import from source, not installed package
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from pipecatcloud._utils.console_utils import OutputMode, PipecatConsole, console
+from pipecatcloud.cli.entry_point import entrypoint_cli_typer
+
+runner = CliRunner()
+
+LONG_ID = "4bb223c4-9f31-44f5-9b3c-c6b8ea9c3a01"
+LONG_DEPLOYMENT_ID = "7c9d1e55-8a76-4a2b-b6ce-2f0d4a9be777"
+
+AGENT_LIST_PAYLOAD = [
+    {
+        "name": "site-survey-agent-with-long-name",
+        "region": "us-east-1",
+        "id": LONG_ID,
+        "activeDeploymentId": LONG_DEPLOYMENT_ID,
+        "createdAt": "2026-07-01T00:00:00.000Z",
+        "updatedAt": "2026-07-20T00:00:00.000Z",
+    }
+]
+
+
+@pytest.fixture(autouse=True)
+def reset_console_mode():
+    """set_output_mode mutates the module singleton; restore it around tests.
+
+    Save the private ``_file`` (normally None = resolve sys.stdout dynamically),
+    not the ``file`` property: reading the property returns the *current*
+    stdout object, and pinning that back would bypass CliRunner's capture.
+    """
+    explicit = console._explicit_output_mode
+    file = console._file
+    yield
+    console._explicit_output_mode = explicit
+    console._file = file
+
+
+def make_console(**kwargs) -> tuple[PipecatConsole, StringIO]:
+    buffer = StringIO()
+    test_console = PipecatConsole(file=buffer, width=80, **kwargs)
+    return test_console, buffer
+
+
+class TestModeResolution:
+    def test_defaults_to_plain_when_not_a_terminal(self):
+        test_console, _ = make_console()
+        assert not test_console.is_terminal
+        assert test_console.output_mode == OutputMode.plain
+
+    def test_explicit_mode_overrides_detection(self):
+        test_console, _ = make_console()
+        test_console.set_output_mode(OutputMode.rich)
+        assert test_console.output_mode == OutputMode.rich
+
+    def test_output_flag_forces_rich(self):
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            mock_api.agents = AsyncMock(return_value=(AGENT_LIST_PAYLOAD, None))
+            result = runner.invoke(entrypoint_cli_typer, ["--output", "rich", "agent", "list"])
+        assert result.exit_code == 0
+        # Rich table output truncates the long IDs at the default 80 columns
+        assert LONG_ID not in result.output
+
+    def test_env_var_selects_mode(self):
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            mock_api.agents = AsyncMock(return_value=(AGENT_LIST_PAYLOAD, None))
+            result = runner.invoke(
+                entrypoint_cli_typer, ["agent", "list"], env={"PIPECAT_OUTPUT": "plain"}
+            )
+        assert result.exit_code == 0
+        assert LONG_ID in result.output
+
+    def test_invalid_env_mode_exits_2(self):
+        result = runner.invoke(
+            entrypoint_cli_typer, ["agent", "list"], env={"PIPECAT_OUTPUT": "yaml"}
+        )
+        assert result.exit_code == 2
+
+    def test_invalid_flag_mode_exits_2(self):
+        result = runner.invoke(entrypoint_cli_typer, ["--output", "yaml", "agent", "list"])
+        assert result.exit_code == 2
+
+    def test_json_mode_moves_console_to_stderr(self):
+        test_console, _ = make_console()
+        test_console.set_output_mode(OutputMode.json)
+        assert test_console.file is sys.stderr
+
+
+class TestPlainStatus:
+    def test_distinct_messages_are_printed_with_timestamps(self):
+        test_console, buffer = make_console()
+        with test_console.status("Waiting for deployment...") as status:
+            status.update("Starting: 0/2 instances ready")
+            status.update("Starting: 1/2 instances ready")
+        output = buffer.getvalue()
+        assert "Waiting for deployment..." in output
+        assert "Starting: 0/2 instances ready" in output
+        assert "Starting: 1/2 instances ready" in output
+        # Timestamped prefix like [12:34:56]
+        assert output.count("[") >= 3
+
+    def test_repeated_messages_are_deduplicated(self):
+        test_console, buffer = make_console()
+        with test_console.status("polling...") as status:
+            for _ in range(10):
+                status.update("still waiting")
+        assert buffer.getvalue().count("still waiting") == 1
+
+    def test_rich_mode_uses_rich_status(self):
+        test_console, _ = make_console(force_terminal=True)
+        test_console.set_output_mode(OutputMode.rich)
+        status = test_console.status("working...")
+        # rich's Status, not our plain sink
+        from rich.status import Status
+
+        assert isinstance(status, Status)
+        status.stop()
+
+
+class TestPlainListings:
+    def test_agent_list_piped_shows_full_ids(self):
+        """The Finding-3 repro: piped `agent list` must not ellipsize IDs."""
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            mock_api.agents = AsyncMock(return_value=(AGENT_LIST_PAYLOAD, None))
+            result = runner.invoke(entrypoint_cli_typer, ["agent", "list"])
+        assert result.exit_code == 0
+        assert LONG_ID in result.output
+        assert LONG_DEPLOYMENT_ID in result.output
+        assert "…" not in result.output
+
+    def test_print_records_emits_tab_separated_rows(self):
+        test_console, buffer = make_console()
+        test_console.print_records(["ID", "Name"], [(LONG_ID, "value with spaces")], title="Things")
+        lines = buffer.getvalue().splitlines()
+        assert lines[0] == "Things"
+        assert lines[1] == "ID\tName"
+        assert lines[2] == f"{LONG_ID}\tvalue with spaces"
+
+    def test_error_is_flat_in_plain_mode(self):
+        test_console, buffer = make_console()
+        test_console.error("something broke")
+        output = buffer.getvalue()
+        assert "something broke" in output
+        assert "╭" not in output  # no panel box art
+
+    def test_error_is_boxed_in_rich_mode(self):
+        test_console, buffer = make_console(force_terminal=True)
+        test_console.set_output_mode(OutputMode.rich)
+        test_console.error("something broke")
+        assert "╭" in buffer.getvalue()
+
+
+class TestRequireInteractive:
+    def test_exits_2_when_stdin_not_a_terminal(self):
+        test_console, buffer = make_console()
+        with patch("pipecatcloud._utils.console_utils.stdin_is_interactive", return_value=False):
+            with pytest.raises(typer.Exit) as exc_info:
+                test_console.require_interactive("--yes")
+        assert exc_info.value.exit_code == 2
+        assert "--yes" in buffer.getvalue()
+
+    def test_noop_when_interactive(self):
+        test_console, _ = make_console()
+        with patch("pipecatcloud._utils.console_utils.stdin_is_interactive", return_value=True):
+            test_console.require_interactive("--yes")
+
+    def test_agent_stop_without_force_exits_2_non_interactively(self):
+        with patch("pipecatcloud.cli.commands.agent.API") as mock_api:
+            mock_api.agent_session_terminate = AsyncMock(return_value=({}, None))
+            result = runner.invoke(
+                entrypoint_cli_typer,
+                ["agent", "stop", "some-agent", "--session-id", "sess-1"],
+            )
+        assert result.exit_code == 2

--- a/tests/test_pat_auth.py
+++ b/tests/test_pat_auth.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import typer
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
@@ -106,7 +107,9 @@ class TestUsePATCommand:
         from pipecatcloud.cli.commands.auth import _use_pat_impl
 
         with patch("pipecatcloud.cli.commands.auth.console") as mock_console:
-            await _use_pat_impl("sk_not-a-pat-token")
+            with pytest.raises(typer.Exit) as exc_info:
+                await _use_pat_impl("sk_not-a-pat-token")
+            assert exc_info.value.exit_code == 1
             mock_console.error.assert_called_once()
             assert "pcc_pat_" in str(mock_console.error.call_args)
 
@@ -155,7 +158,9 @@ class TestUsePATCommand:
         ):
             mock_get_org.side_effect = Exception("401 Unauthorized")
 
-            await _use_pat_impl("pcc_pat_0000000000000000000000000000dead")
+            with pytest.raises(typer.Exit) as exc_info:
+                await _use_pat_impl("pcc_pat_0000000000000000000000000000dead")
 
+            assert exc_info.value.exit_code == 1
             mock_console.error.assert_called_once()
             mock_update.assert_not_called()

--- a/tests/test_spend_limit.py
+++ b/tests/test_spend_limit.py
@@ -271,16 +271,16 @@ class TestSpendLimitSetCommand:
         ):
             mock_q.confirm.return_value.ask_async = AsyncMock(return_value=False)
 
-            result = set_limit(
-                amount="50",
-                organization="test-org",
-                yes=False,
-            )
+            with pytest.raises(typer.Exit) as exc_info:
+                set_limit(
+                    amount="50",
+                    organization="test-org",
+                    yes=False,
+                )
 
             mock_q.confirm.assert_called_once()
             mock_api.spend_limit_update.assert_not_called()
-            assert isinstance(result, typer.Exit)
-            assert result.exit_code == 1
+            assert exc_info.value.exit_code == 1
 
     def test_set_aborts_when_zero_rejected(self):
         mock_api = MagicMock()
@@ -293,16 +293,16 @@ class TestSpendLimitSetCommand:
         ):
             mock_q.confirm.return_value.ask_async = AsyncMock(return_value=False)
 
-            result = set_limit(
-                amount="0",
-                organization="test-org",
-                yes=False,
-            )
+            with pytest.raises(typer.Exit) as exc_info:
+                set_limit(
+                    amount="0",
+                    organization="test-org",
+                    yes=False,
+                )
 
             mock_q.confirm.assert_called_once()
             mock_api.spend_limit_update.assert_not_called()
-            assert isinstance(result, typer.Exit)
-            assert result.exit_code == 1
+            assert exc_info.value.exit_code == 1
 
 
 class TestSpendLimitClearCommand:
@@ -329,9 +329,9 @@ class TestSpendLimitClearCommand:
         ):
             mock_q.confirm.return_value.ask_async = AsyncMock(return_value=False)
 
-            result = clear(organization="test-org", yes=False)
+            with pytest.raises(typer.Exit) as exc_info:
+                clear(organization="test-org", yes=False)
 
             mock_q.confirm.assert_called_once()
             mock_api.spend_limit_update.assert_not_called()
-            assert isinstance(result, typer.Exit)
-            assert result.exit_code == 1
+            assert exc_info.value.exit_code == 1

--- a/tests/test_spend_limit.py
+++ b/tests/test_spend_limit.py
@@ -268,6 +268,7 @@ class TestSpendLimitSetCommand:
         with (
             patch("pipecatcloud.cli.commands.spend_limit.API", mock_api),
             patch("pipecatcloud.cli.commands.spend_limit.questionary") as mock_q,
+            patch("pipecatcloud._utils.console_utils.stdin_is_interactive", return_value=True),
         ):
             mock_q.confirm.return_value.ask_async = AsyncMock(return_value=False)
 
@@ -290,6 +291,7 @@ class TestSpendLimitSetCommand:
         with (
             patch("pipecatcloud.cli.commands.spend_limit.API", mock_api),
             patch("pipecatcloud.cli.commands.spend_limit.questionary") as mock_q,
+            patch("pipecatcloud._utils.console_utils.stdin_is_interactive", return_value=True),
         ):
             mock_q.confirm.return_value.ask_async = AsyncMock(return_value=False)
 
@@ -326,6 +328,7 @@ class TestSpendLimitClearCommand:
         with (
             patch("pipecatcloud.cli.commands.spend_limit.API", mock_api),
             patch("pipecatcloud.cli.commands.spend_limit.questionary") as mock_q,
+            patch("pipecatcloud._utils.console_utils.stdin_is_interactive", return_value=True),
         ):
             mock_q.confirm.return_value.ask_async = AsyncMock(return_value=False)
 

--- a/tests/test_spend_limit.py
+++ b/tests/test_spend_limit.py
@@ -242,6 +242,39 @@ class TestSpendLimitShowCommand:
 
 
 class TestSpendLimitSetCommand:
+    def test_set_without_prompt_condition_works_non_interactively(self):
+        """A plain limit raise shows no prompt interactively, so it must not
+        demand --yes when stdin is not a terminal (guard sits inside the
+        prompt branches, not above them)."""
+        mock_api = MagicMock()
+        mock_api.spend_limit_get = AsyncMock(return_value=({"currentSpendCents": 0}, None))
+        mock_api.spend_limit_update = AsyncMock(return_value=({"limitCents": 5000}, None))
+
+        with (
+            patch("pipecatcloud.cli.commands.spend_limit.API", mock_api),
+            patch("pipecatcloud._utils.console_utils.stdin_is_interactive", return_value=False),
+        ):
+            set_limit(amount="50", organization="test-org", yes=False)
+
+            mock_api.spend_limit_update.assert_awaited_once_with("test-org", 5000)
+
+    def test_set_zero_requires_terminal_or_yes(self):
+        """Setting $0 blocks all sessions and always prompts, so non-TTY
+        without --yes must fail fast with a usage error."""
+        mock_api = MagicMock()
+        mock_api.spend_limit_get = AsyncMock(return_value=({"currentSpendCents": 0}, None))
+        mock_api.spend_limit_update = AsyncMock()
+
+        with (
+            patch("pipecatcloud.cli.commands.spend_limit.API", mock_api),
+            patch("pipecatcloud._utils.console_utils.stdin_is_interactive", return_value=False),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                set_limit(amount="0", organization="test-org", yes=False)
+
+            assert exc_info.value.exit_code == 2
+            mock_api.spend_limit_update.assert_not_called()
+
     def test_set_skips_prompt_when_yes_flag(self):
         mock_api = MagicMock()
         mock_api.spend_limit_get = AsyncMock(return_value=({"currentSpendCents": 0}, None))


### PR DESCRIPTION
Implements [PCC-1064](https://linear.app/dailyco/issue/PCC-1064/cli-add-non-interactive-output-mode-exit-codes-progress-machine): the full non-interactive story for the CLI, phased as five commits. Origin: Quadriga's report of silent deploys and `Image: N/A`, which turned out to sit on top of a more serious undiscovered problem — the CLI exits 0 on every failure.

## Commit 1 — exit codes (`fix: raise typer.Exit instead of returning it`)

Typer discards a command's return value, so all ~125 `return typer.Exit(1)` sites never fired and every failure exited 0. Converted to raises with per-site triage rather than a blind sweep, because the sweep surfaced additional variants:

- bare `return typer.Exit()` (defaults to code 0) on dozens of error paths
- discarded `typer.Exit(1)` statements (one would have crashed `keys revoke` on a cancelled prompt)
- `requires_login` bailing out with a plain `return` (the ticket's headline repro)
- three commands wrapping their body in `except Exception`, which swallows a raised `typer.Exit` (it subclasses `Exception`) — these got `except typer.Exit: raise` pass-throughs
- `_deploy()`'s returned Exit being ignored by its caller, and a secrets-validation helper whose returned Exit was ignored, meaning invalid secrets passed validation

Conventions: errors and user cancellations exit 1; success exits 0; usage errors exit 2. Deploy's "available but not fully rolled out" soft-warning still exits 0 (failing slow-but-healthy rollouts in CI seemed wrong); degraded and hard-timeout exit 1.

New `CliRunner`-based tests assert real process exit codes end to end (the old tests asserted on the returned `typer.Exit` object, which passes whether or not the process ever exits non-zero), plus a regression-guard test that fails on any reintroduced `return`/discarded `typer.Exit`.

## Commit 2 — output modes (`feat: output modes for non-interactive use`)

Global `--output {rich,plain,json}` on the callback, also via `PIPECAT_OUTPUT` or the `output` config key. Auto-selects `plain` when stdout is not a terminal.

- `PipecatConsole.status()` now returns a timestamped, deduplicating line-printer in non-rich modes instead of a Rich spinner that renders nothing when piped. This makes the up-to-600s deploy poll loop and cloud-build polling visible in CI with near-zero call-site churn; the `Live(console.status(...))` composites were folded into it. Cloud-build polling now also surfaces build-status transitions (previously computed and discarded).
- Listings render tab-separated with full values in plain mode via `print_records()`, written directly to the stream — Rich otherwise tab-expands, wraps, or ellipsizes at 80 columns, which silently corrupts IDs consumed by scripts.
- Panels degrade to flat prefixed lines in plain mode.
- `require_interactive()`: commands that would prompt exit 2 with a pointer to the bypass flag (`--yes`/`--force`/`--skip`) when stdin is not a terminal, instead of hanging or misbehaving. `keys create`'s make-default prompt instead degrades to "no" non-interactively, since the key is already created server-side at that point.

## Commit 3 — JSON mode (`feat: machine-readable JSON output`)

Contract: exactly one JSON object on stdout; all human output on stderr; failures exit non-zero, API errors also emitted as `{"error": ...}` on stdout. This lifts the stdout-purity handling that `spend-limit show --json` solved locally into `_API.print_error`; the `--json` flag remains as a deprecated alias. Covered: agent list/status/sessions/deployments/logs/start, deploy, secrets list, organizations list/keys/properties/schema, regions, build status/logs/list, spend-limit show/set/clear, auth whoami.

## Commit 4 — build ID (`fix: show Build ID when the deployment image is redacted`)

`agent status` and `agent deployments` show `Build: <buildId>` for cloud-built deployments instead of `Image: N/A`. Pure CLI change — the responses already carry `buildId`.

## Verification

- 272 tests pass (baseline 243); ruff format/check clean; pyright 44 errors vs 45 on main
- Real-CLI verification of the original repro: `agent status nonexistent-agent-xyz` piped now exits 1 with a flat timestamped error; `--output json` yields pure parseable stdout with the error object
- Release note: recommend tagging as **v1.1.0** (new features + observable exit-code behavior change); CHANGELOG has the full customer-facing notes under `[Unreleased]`, with the exit-code change called out prominently

## Known gaps / flagged, not fixed

- `console.print(Panel)` sites (e.g. the deploy review panel) still draw boxes in plain mode — lossless wrapping, cosmetic only
- `docker build` has no `--yes` flag, so its confirm exits 2 non-interactively rather than being bypassable
- Pre-existing latent bug left alone: `scaling_panel` possibly unbound in `agent status`'s rich path when the API omits `autoScaling` (agent.py:391, pyright flags it)
