### PR TITLE
Align organization terminology across the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   code `2` when stdin is not a terminal, pointing at the bypass flag
   (`--yes`/`--force`/`--skip`), instead of hanging or misbehaving in CI.
 
+- `organizations list` and `organizations keys create` label their
+  organization columns **Organization Name** (the display name) and
+  **Organization ID** (the identifier `--organization` takes), matching
+  the dashboard. The values are unchanged, as is `--output json`, which
+  emits the server's own field names. Scripts parsing the previous
+  `Organization` / `Name` headers out of `--output plain` need updating.
+
 ### Deprecated
 
 - `spend-limit show --json` still works but is now an alias for the global

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `spend-limit show --json` still works but is now an alias for the global
   `--output json` mode.
 
+### Fixed
+
+- `organizations keys create` no longer reports a new key as "Using as
+  default in local config" when it was not stored as the default. The
+  panel carries that note only when the key actually became the default.
+
 ## [1.0.1] - 2026-07-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   organization columns **Organization Name** (the display name) and
   **Organization ID** (the identifier `--organization` takes), matching
   the dashboard. The values are unchanged, as is `--output json`, which
-  emits the server's own field names. Scripts parsing the previous
-  `Organization` / `Name` headers out of `--output plain` need updating.
+  emits the server's own field names. Scripts scraping the previous
+  `Organization` / `Name` headers out of table output need updating. In
+  `organizations list`, the active-organization marker moved to its own
+  `Active` column, so the ID column holds nothing but the identifier.
 
 - CLI messages call an organization an "organization" rather than a
   "namespace". The Kubernetes namespace an organization maps to is an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emits the server's own field names. Scripts parsing the previous
   `Organization` / `Name` headers out of `--output plain` need updating.
 
+- CLI messages call an organization an "organization" rather than a
+  "namespace". The Kubernetes namespace an organization maps to is an
+  implementation detail, so messages about missing agents, secret sets,
+  or accounts now name the organization. `organizations select` reports
+  an unmatched `--organization` value as an unknown organization ID and
+  points at `organizations list`.
+
 ### Deprecated
 
 - `spend-limit show --json` still works but is now an alias for the global

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -136,7 +136,7 @@ async def list_agents(
 
         if not data or len(data) == 0:
             console.error(
-                f"[red]No agents found for namespace / organization '{org}'[/red]\n\n"
+                f"[red]No agents found for organization '{org}'[/red]\n\n"
                 f"[dim]Please deploy an agent first using[/dim] [bold cyan]{PIPECAT_CLI_NAME} deploy[/bold cyan]"
             )
             raise typer.Exit(1)
@@ -835,7 +835,7 @@ async def delete(
             raise typer.Exit(1)
 
         if not data:
-            console.error(f"Agent '{agent_name}' not found in namespace / organization '{org}'")
+            console.error(f"Agent '{agent_name}' not found in organization '{org}'")
             raise typer.Exit(1)
 
         console.success(f"Agent '{agent_name}' deleted successfully")

--- a/src/pipecatcloud/cli/commands/auth.py
+++ b/src/pipecatcloud/cli/commands/auth.py
@@ -443,7 +443,7 @@ async def login():
         account_name, account_name_verbose = await _get_account_org(access_token, active_org)
         if account_name is None:
             console.error(
-                "Account has no associated namespace. "
+                "Account has no associated organization. "
                 "Have you completed the onboarding process? "
                 "Please first sign in via the web dashboard."
             )
@@ -543,7 +543,7 @@ async def _use_pat_impl(token: str):
             account_name, account_name_verbose = await _get_account_org(token, active_org)
             if account_name is None:
                 console.error(
-                    "Token is valid but account has no associated namespace. "
+                    "Token is valid but account has no associated organization. "
                     "Have you completed the onboarding process?"
                 )
                 raise typer.Exit(1)
@@ -597,7 +597,7 @@ async def whomai():
             if error:
                 raise typer.Exit(1)
 
-            live.update("[dim]Requesting user namespace / organization data...[/dim]")
+            live.update("[dim]Requesting user organization data...[/dim]")
 
             # Retrieve default user organization. The API wrapper already
             # reported the error (create_api_method calls print_error), so

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -318,7 +318,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
             if not secrets_exist:
                 live.stop()
                 console.error(
-                    f"Secret set [bold]'{params.secret_set}'[/bold] not found in namespace [bold]'{org}'[/bold]"
+                    f"Secret set [bold]'{params.secret_set}'[/bold] not found in organization [bold]'{org}'[/bold]"
                 )
                 raise typer.Exit(1)
 
@@ -344,7 +344,7 @@ async def _deploy(params: DeployConfigParams, org, force: bool = False):
             if not creds_exist:
                 live.stop()
                 console.error(
-                    f"Image pull secret with name [bold]'{params.image_credentials}'[/bold] not found in namespace [bold]'{org}'[/bold]"
+                    f"Image pull secret with name [bold]'{params.image_credentials}'[/bold] not found in organization [bold]'{org}'[/bold]"
                 )
                 raise typer.Exit(1)
 

--- a/src/pipecatcloud/cli/commands/organizations.py
+++ b/src/pipecatcloud/cli/commands/organizations.py
@@ -40,9 +40,7 @@ organization_cli.add_typer(properties_cli)
 async def select(organization: str = typer.Option(None, "--organization", "-o")):
     current_org = config.get("org")
 
-    with console.status(
-        "[dim]Retrieve user namespace / organization data...[/dim]", spinner="dots"
-    ):
+    with console.status("[dim]Retrieve user organization data...[/dim]", spinner="dots"):
         org_list, error = await API.organizations()
 
         if error:
@@ -54,7 +52,7 @@ async def select(organization: str = typer.Option(None, "--organization", "-o"))
             console.require_interactive("--organization")
             # Prompt user to select organization
             value = await questionary.select(
-                "Select default namespace / organization",
+                "Select default organization",
                 choices=[
                     {
                         "name": f"{org['verboseName']} ({org['name']})",
@@ -78,7 +76,9 @@ async def select(organization: str = typer.Option(None, "--organization", "-o"))
                     match = o
             if not match:
                 console.error(
-                    f"Unable to find namespace [bold]'{organization}'[/bold] in user's available organizations"
+                    f"No organization with ID [bold]'{organization}'[/bold].\n"
+                    f"[dim]Run [bold]{PIPECAT_CLI_NAME} organizations list[/bold] "
+                    f"to see available IDs.[/dim]"
                 )
                 raise typer.Exit(1)
             selected_org = match["name"], match["verboseName"]
@@ -88,7 +88,7 @@ async def select(organization: str = typer.Option(None, "--organization", "-o"))
 
         console.success(
             f"Current organization set to [bold green]{selected_org[1]} [dim]({selected_org[0]})[/dim][/bold green]\n"
-            f"[dim]Default namespace updated in {user_config_path}[/dim]"
+            f"[dim]Default organization updated in {user_config_path}[/dim]"
         )
     except typer.Exit:
         raise
@@ -103,9 +103,7 @@ async def select(organization: str = typer.Option(None, "--organization", "-o"))
 async def list_organizations():
     current_org = config.get("org")
 
-    with console.status(
-        "[dim]Retrieve user namespace / organization data...[/dim]", spinner="dots"
-    ):
+    with console.status("[dim]Retrieve user organization data...[/dim]", spinner="dots"):
         org_list, error = await API.organizations()
 
         if error:
@@ -113,7 +111,7 @@ async def list_organizations():
 
     if not org_list or not len(org_list):
         console.error(
-            "No namespaces associated with user account. Please complete onboarding via the dashboard.",
+            "No organizations associated with user account. Please complete onboarding via the dashboard.",
             subtitle=config.get("dashboard_host"),
         )
         raise typer.Exit(1)

--- a/src/pipecatcloud/cli/commands/organizations.py
+++ b/src/pipecatcloud/cli/commands/organizations.py
@@ -324,7 +324,10 @@ async def create_key(
         org,
     )
 
-    console.success(table, subtitle="Using as default in local config")
+    console.success(
+        table,
+        subtitle="Using as default in local config" if make_active else None,
+    )
 
 
 async def _revoke_key_flow(organization: str | None) -> None:

--- a/src/pipecatcloud/cli/commands/organizations.py
+++ b/src/pipecatcloud/cli/commands/organizations.py
@@ -139,14 +139,17 @@ async def list_organizations():
     # API paths, the k8s namespace, and `--organization`.
     table.add_column("Organization Name", style="white")
     table.add_column("Organization ID", style="white")
+    # The active marker gets its own column so the ID cell holds nothing but
+    # the value `--organization` accepts.
+    table.add_column("Active", style="white")
     for org in org_list:
-        if current_org and org["name"] == current_org:
-            table.add_row(
-                f"[cyan bold]{org['verboseName']}[/cyan bold]",
-                f"[cyan bold]{org['name']} (active)[/cyan bold]",
-            )
-        else:
-            table.add_row(org["verboseName"], org["name"])
+        active = bool(current_org and org["name"] == current_org)
+        table.add_row(
+            org["verboseName"],
+            org["name"],
+            "active" if active else "",
+            style="cyan bold" if active else None,
+        )
 
     console.success(table, title_extra=f"{len(org_list)} results")
 

--- a/src/pipecatcloud/cli/commands/organizations.py
+++ b/src/pipecatcloud/cli/commands/organizations.py
@@ -124,7 +124,7 @@ async def list_organizations():
 
     if not console.rich_output:
         console.print_records(
-            ["Organization", "Name", "Active"],
+            ["Organization Name", "Organization ID", "Active"],
             [
                 (
                     org["verboseName"],
@@ -137,8 +137,10 @@ async def list_organizations():
         return
 
     table = Table(border_style="dim", box=box.SIMPLE, show_edge=True, show_lines=False)
-    table.add_column("Organization", style="white")
-    table.add_column("Name", style="white")
+    # `verboseName` is the display string; `name` is the unique slug used in
+    # API paths, the k8s namespace, and `--organization`.
+    table.add_column("Organization Name", style="white")
+    table.add_column("Organization ID", style="white")
     for org in org_list:
         if current_org and org["name"] == current_org:
             table.add_row(
@@ -301,7 +303,7 @@ async def create_key(
 
     if not console.rich_output:
         console.print_records(
-            ["Name", "Key", "Organization"],
+            ["Name", "Key", "Organization ID"],
             [(api_key_name, data["key"], org)],
         )
         return
@@ -314,7 +316,7 @@ async def create_key(
     )
     table.add_column("Name")
     table.add_column("Key")
-    table.add_column("Organization")
+    table.add_column("Organization ID")
 
     table.add_row(
         api_key_name,

--- a/src/pipecatcloud/cli/commands/secrets.py
+++ b/src/pipecatcloud/cli/commands/secrets.py
@@ -416,7 +416,7 @@ async def list_sets(
                     f"No secrets sets with name [bold]'{name}'[/bold] found in [bold]'{org}'[/bold]"
                 )
             else:
-                console.error(f"No secrets sets for namespace / organization [bold]'{org}'[/bold]")
+                console.error(f"No secret sets for organization [bold]'{org}'[/bold]")
             raise typer.Exit(1)
 
         if name:
@@ -460,7 +460,7 @@ async def list_sets(
             filtered_sets = [s for s in data if show_all or s["type"] != "imagePullSecret"]
 
             if not filtered_sets or not len(filtered_sets):
-                console.error(f"No secret sets in namespace / organization [bold]'{org}'[/bold]")
+                console.error(f"No secret sets in organization [bold]'{org}'[/bold]")
                 raise typer.Exit(1)
 
             if console.json_output:

--- a/src/pipecatcloud/cli/config.py
+++ b/src/pipecatcloud/cli/config.py
@@ -142,7 +142,7 @@ def update_user_config(
         if additional_data:
             existing_config[active_org].update(additional_data)
     elif additional_data:
-        raise ValueError("Attempt to store additional data without specifying namespace")
+        raise ValueError("Attempt to store additional data without specifying organization")
 
     try:
         _write_user_config(existing_config)

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -39,6 +39,18 @@ class TestOrganizationColumnLabels:
         assert "Organization Name" in result.output
         assert "Organization ID" in result.output
 
+    def test_rich_id_cell_holds_only_the_identifier(self):
+        # conftest pins the active org to "test-org". The active marker must
+        # not end up inside the cell users copy into --organization.
+        with patch("pipecatcloud.cli.commands.organizations.API") as mock_api:
+            mock_api.organizations = AsyncMock(return_value=(ORG_LIST_PAYLOAD, None))
+            result = runner.invoke(
+                entrypoint_cli_typer, ["--output", "rich", "organizations", "list"]
+            )
+        assert result.exit_code == 0
+        assert "test-org (active)" not in result.output
+        assert "active" in result.output
+
     def test_plain_list_labels_both_columns(self):
         with patch("pipecatcloud.cli.commands.organizations.API") as mock_api:
             mock_api.organizations = AsyncMock(return_value=(ORG_LIST_PAYLOAD, None))

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -1,0 +1,91 @@
+"""Tests for the organizations commands.
+
+Covers the column labels shared with the dashboard and the API-key create
+flow's default-key messaging.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+# Import from source, not installed package
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from pipecatcloud.cli.entry_point import entrypoint_cli_typer
+
+runner = CliRunner()
+
+ORG_LIST_PAYLOAD = [
+    {"name": "gradientbang", "verboseName": "Gradient Bang"},
+    {"name": "test-org", "verboseName": "Default Workspace"},
+]
+
+KEY_CREATE_ARGS = ["organizations", "keys", "create", "--name", "Pipecat Key"]
+
+
+class TestOrganizationColumnLabels:
+    """`verboseName` is "Organization Name" and `name` is "Organization ID",
+    matching the dashboard."""
+
+    def test_rich_list_labels_both_columns(self):
+        with patch("pipecatcloud.cli.commands.organizations.API") as mock_api:
+            mock_api.organizations = AsyncMock(return_value=(ORG_LIST_PAYLOAD, None))
+            result = runner.invoke(
+                entrypoint_cli_typer, ["--output", "rich", "organizations", "list"]
+            )
+        assert result.exit_code == 0
+        assert "Organization Name" in result.output
+        assert "Organization ID" in result.output
+
+    def test_plain_list_labels_both_columns(self):
+        with patch("pipecatcloud.cli.commands.organizations.API") as mock_api:
+            mock_api.organizations = AsyncMock(return_value=(ORG_LIST_PAYLOAD, None))
+            result = runner.invoke(
+                entrypoint_cli_typer, ["--output", "plain", "organizations", "list"]
+            )
+        assert result.exit_code == 0
+        assert "Organization Name\tOrganization ID\tActive" in result.output
+
+    def test_json_list_keeps_server_field_names(self):
+        import json
+
+        with patch("pipecatcloud.cli.commands.organizations.API") as mock_api:
+            mock_api.organizations = AsyncMock(return_value=(ORG_LIST_PAYLOAD, None))
+            result = runner.invoke(
+                entrypoint_cli_typer, ["--output", "json", "organizations", "list"]
+            )
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == {"organizations": ORG_LIST_PAYLOAD}
+
+
+class TestApiKeyCreateDefaultMessaging:
+    """The success panel's subtitle must agree with whether the key was
+    actually stored as the local default."""
+
+    def _create(self, extra_args=()):
+        with (
+            patch("pipecatcloud.cli.commands.organizations.API") as mock_api,
+            patch("pipecatcloud.cli.commands.organizations.update_user_config") as mock_update,
+        ):
+            mock_api.api_key_create = AsyncMock(return_value=({"key": "pk_abc123"}, None))
+            result = runner.invoke(
+                entrypoint_cli_typer, ["--output", "rich", *KEY_CREATE_ARGS, *extra_args]
+            )
+        return result, mock_update
+
+    def test_declined_default_is_not_reported_as_active(self):
+        # Without --default and with a non-interactive stdin the key is not
+        # stored, so the panel must not claim otherwise.
+        result, mock_update = self._create()
+        assert result.exit_code == 0
+        assert "Bypassing using key as default" in result.output
+        assert "Using as default in local config" not in result.output
+        mock_update.assert_not_called()
+
+    def test_default_flag_is_reported_as_active(self):
+        result, mock_update = self._create(["--default"])
+        assert result.exit_code == 0
+        assert "Using as default in local config" in result.output
+        mock_update.assert_called_once()


### PR DESCRIPTION
Settles on one vocabulary for organizations across the CLI, and fixes a stale message in the API-key create flow.

## Column labels

`organizations list` and `organizations keys create` show **Organization Name** and **Organization ID**, matching the dashboard:

```
  Organization Name   Organization ID                Active
 ───────────────────────────────────────────────────────────
  Gradient Bang       gradientbang
  Default Workspace   smiling-silkworm-apricot-197   active
  Daily Demos         daily-demos
  voide-agent         whole-perch-olive-968
```

The active marker sits in its own `Active` column, matching what the plain renderer already emitted, so the ID cell holds nothing but the value `--organization` accepts.

The labels do not map onto the server's field names. `api/src/models/organization.ts` defines three fields:

| Field | Type | Example | Role |
|---|---|---|---|
| `id` | UUID v4, PK | `3f2b…` | Internal. Included in `GET /v1/organizations` responses, surfaced in neither client. |
| `name` | string, unique | `smiling-silkworm-apricot-197` | Path segment in every route (`/v1/organizations/:name/…`), the Kubernetes namespace, and the value `--organization` takes. |
| `verboseName` | string | `Default Workspace` | Display name. Editable via `PUT /v1/organizations/:name`. |

"Organization Name" is `verboseName` and "Organization ID" is `name`. The UUID has no user-facing surface, so "ID" is unambiguous to users despite not being the `id` field.

`--output json` emits `name` and `verboseName` unchanged. The labels are presentation only, so machine consumers keep tracking the API's field names.

## "namespace" is gone from user-facing text

CLI messages name the organization rather than the Kubernetes namespace it maps to. Fifteen strings across five files changed, either dropping the hedged "namespace / organization" or replacing a bare "namespace":

```
No agents found for organization 'x'                    agent.py
Agent 'y' not found in organization 'x'                 agent.py
Account has no associated organization.                 auth.py
Requesting user organization data...                    auth.py, organizations.py
Secret set 'y' not found in organization 'x'            deploy.py
No secret sets for organization 'x'                     secrets.py
Select default organization                             organizations.py
Default organization updated in {path}                  organizations.py
No organizations associated with user account.          organizations.py
```

The namespace has no CLI surface to break: it is not a flag, a config key, a `pcc-deploy.toml` field, or an API payload key. The word only ever reached users as prose, so this is a copy change.

One message is rewritten rather than substituted. `organizations select` with an unmatched `--organization` value now names the field and points at the command that lists it, since the likely cause is passing the display name where the ID belongs:

```
╭─ ᓚᘏᗢ Error ──────────────────────────────────────────────────────────────────╮
│ No organization with ID 'Default Workspace'.                                 │
│ Run pipecat cloud organizations list to see available IDs.                   │
╰──────────────────────────────────────────────────────────────────────────────╯
```

The one surviving "namespace" is a comment in `organizations.py` describing what the slug is used for server-side.

## Default-key message

`organizations keys create` carries "Using as default in local config" on its success panel only when the key was actually stored as the local default. Declining the prompt, or creating a key non-interactively without `--default`, leaves the panel without that note.

## Tests

`tests/test_organizations.py` is new: column labels in all three output modes, and the default-key messaging in both directions.

## Upgrade note

Scripts scraping the `Organization` / `Name` headers out of table output, or matching CLI stderr on the word "namespace", need updating. Both surfaces shipped in v1.0.1. The plain renderer ships for the first time in this release, so its headers have no existing consumers.

## Follow-up

The public docs at docs.pipecat.ai live outside this repo and were not checked for the same "namespace" wording.
