### PR TITLE
docs: finalize CHANGELOG for 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to **Pipecat Cloud** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2026-08-05
 
 ### Added
 


### PR DESCRIPTION
Release prep for 1.1.0. One line changes: `## [Unreleased]` becomes `## [1.1.0] - 2026-08-05`.

## Merge order

Land #190 (Dependabot lock updates) before tagging, so the tagged commit carries the dependency fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)