### PR TITLE
Add region lifecycle + registry-key commands (PCC-1103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default architectures (Daily-hosted regions are arm64-only today), and
   `pipecat cloud agent status` shows the deployment's architecture.
 
+- Region lifecycle commands for **self-hosted regions**. `pipecat cloud
+  regions register <key>` registers or updates a region (an omit-preserves
+  upsert: options you leave out keep their stored values), with a one-question
+  display-name prompt so region pickers show a friendly name instead of the
+  uppercased key. `regions show <key>` prints the full record, including the
+  enrollment status and intermediate certificate expiry. `regions delete
+  <key>` revokes a region, surfacing the server's refusal while live sessions
+  or deployed services exist; `--force` bypasses both the prompt and the
+  guard. `regions enroll-token <key>` mints the one-time enrollment token and
+  prints the ready-to-paste `kubectl create secret` command.
+
+- New `pipecat cloud organizations registry-keys` command group for the
+  pull-only registry credentials that fetch the region package chart:
+  `mint` (the key is shown exactly once, with the matching
+  `helm registry login` command), `list` (lifecycle metadata only, never key
+  material), and `revoke`. With these plus `regions register` and
+  `regions enroll-token`, a self-hosted region's control-plane setup needs no
+  raw API calls.
+
 - Explicit agent sizing for **enterprise (self-hosted) regions**. Deploys can
   now state resources directly instead of selecting an agent profile:
   `pipecat cloud deploy --resources cpu=2,memory=4Gi`, or a `[resources]`

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -755,6 +755,116 @@ class _API:
         """
         return self.create_api_method(self._regions)
 
+    # Self-hosted region lifecycle (PCC-1103). Registration is an
+    # omit-preserves upsert: fields absent from the payload keep their stored
+    # values on the server.
+
+    async def _region_register(self, org: str, payload: dict) -> dict:
+        url = self.construct_api_url("regions_path").format(org=org)
+        return await self._base_request("POST", url, json=payload) or {}
+
+    @property
+    def region_register(self):
+        """Register or update a self-hosted region (omit-preserves upsert).
+        Args:
+            org: Organization ID
+            payload: owner-declared fields (regionKey required; workloadsNamespace,
+                supportedArchitectures, defaultArchitecture, wsPublicEndpoint,
+                displayName all optional — omitted fields are preserved)
+        Returns:
+            The full region record.
+        """
+        return self.create_api_method(self._region_register)
+
+    async def _region_get(self, org: str, region_key: str) -> dict | None:
+        url = f"{self.construct_api_url('regions_path').format(org=org)}/{region_key}"
+        return await self._base_request("GET", url, not_found_is_empty=True)
+
+    @property
+    def region_get(self):
+        """Fetch one self-hosted region's full record (enrollment status,
+        intermediate expiry, ws endpoint, architectures, workloads namespace).
+        Args:
+            org: Organization ID
+            region_key: the region's key
+        """
+        return self.create_api_method(self._region_get)
+
+    async def _region_delete(self, org: str, region_key: str, force: bool = False) -> dict | None:
+        url = f"{self.construct_api_url('regions_path').format(org=org)}/{region_key}"
+        if force:
+            url += "?force=true"
+        return await self._base_request("DELETE", url)
+
+    @property
+    def region_delete(self):
+        """Revoke a self-hosted region. Without force the server refuses (409)
+        while the region has live sessions or deployed services.
+        Args:
+            org: Organization ID
+            region_key: the region's key
+            force: bypass the live-workload guard
+        """
+        return self.create_api_method(self._region_delete)
+
+    async def _region_enroll_token(self, org: str, region_key: str) -> dict:
+        url = f"{self.construct_api_url('regions_path').format(org=org)}/{region_key}/enrollment-tokens"
+        return await self._base_request("POST", url, json={}) or {}
+
+    @property
+    def region_enroll_token(self):
+        """Mint a one-time enrollment token for a self-hosted region. The
+        token is returned exactly once.
+        Args:
+            org: Organization ID
+            region_key: the region's key
+        """
+        return self.create_api_method(self._region_enroll_token)
+
+    # Registry pull keys (PCC-1082/PCC-1103): org-scoped, pull-only
+    # credentials for fetching the region package chart from the registry.
+
+    async def _registry_keys(self, org: str) -> dict:
+        url = self.construct_api_url("registry_keys_path").format(org=org)
+        return await self._base_request("GET", url) or {}
+
+    @property
+    def registry_keys(self):
+        """List the organization's registry keys (names and lifecycle
+        metadata only — key material is shown once, at mint).
+        Args:
+            org: Organization ID
+        """
+        return self.create_api_method(self._registry_keys)
+
+    async def _registry_key_mint(self, org: str, name: str | None = None) -> dict:
+        url = self.construct_api_url("registry_keys_path").format(org=org)
+        payload: dict = {"name": name} if name else {}
+        return await self._base_request("POST", url, json=payload) or {}
+
+    @property
+    def registry_key_mint(self):
+        """Mint a registry pull key. The key material in the response is
+        shown exactly once and cannot be retrieved again.
+        Args:
+            org: Organization ID
+            name: optional human label for the key
+        """
+        return self.create_api_method(self._registry_key_mint)
+
+    async def _registry_key_revoke(self, org: str, key_id: str) -> dict | None:
+        url = f"{self.construct_api_url('registry_keys_path').format(org=org)}/{key_id}"
+        return await self._base_request("DELETE", url)
+
+    @property
+    def registry_key_revoke(self):
+        """Revoke a registry key by id.
+        Args:
+            org: Organization ID
+            key_id: the key's id (from registry_keys)
+        """
+        return self.create_api_method(self._registry_key_revoke)
+
     # Organization Properties
 
     async def _properties(self, org: str) -> dict | None:

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -837,10 +837,9 @@ class _API:
         """
         return self.create_api_method(self._registry_keys)
 
-    async def _registry_key_mint(self, org: str, name: str | None = None) -> dict:
+    async def _registry_key_mint(self, org: str, name: str) -> dict:
         url = self.construct_api_url("registry_keys_path").format(org=org)
-        payload: dict = {"name": name} if name else {}
-        return await self._base_request("POST", url, json=payload) or {}
+        return await self._base_request("POST", url, json={"name": name}) or {}
 
     @property
     def registry_key_mint(self):
@@ -848,7 +847,7 @@ class _API:
         shown exactly once and cannot be retrieved again.
         Args:
             org: Organization ID
-            name: optional human label for the key
+            name: human label for the key (the API requires one)
         """
         return self.create_api_method(self._registry_key_mint)
 

--- a/src/pipecatcloud/cli/commands/organizations.py
+++ b/src/pipecatcloud/cli/commands/organizations.py
@@ -16,6 +16,7 @@ from pipecatcloud._utils.auth_utils import requires_login
 from pipecatcloud._utils.console_utils import console, stdin_is_interactive
 from pipecatcloud.cli import PIPECAT_CLI_NAME
 from pipecatcloud.cli.api import API
+from pipecatcloud.cli.commands.registry_keys import registry_keys_cli
 from pipecatcloud.cli.config import (
     config,
     update_user_config,
@@ -30,6 +31,7 @@ properties_cli = typer.Typer(
     name="properties", help="Organization property management", no_args_is_help=True
 )
 organization_cli.add_typer(keys_cli)
+organization_cli.add_typer(registry_keys_cli)
 organization_cli.add_typer(properties_cli)
 
 

--- a/src/pipecatcloud/cli/commands/regions.py
+++ b/src/pipecatcloud/cli/commands/regions.py
@@ -153,7 +153,7 @@ async def register_region(
     # A region without a display name renders as its uppercased key in every
     # picker — worth one interactive question, skippable with Enter (the
     # upsert preserves whatever is stored).
-    if display_name is None and console.is_terminal:
+    if display_name is None and console.is_terminal and not console.json_output:
         answer = await questionary.text(
             "Display name for region pickers (Enter to skip):"
         ).ask_async()

--- a/src/pipecatcloud/cli/commands/regions.py
+++ b/src/pipecatcloud/cli/commands/regions.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import questionary
 import typer
 from rich.table import Table
 
@@ -11,6 +12,8 @@ from pipecatcloud._utils.async_utils import synchronizer
 from pipecatcloud._utils.auth_utils import requires_login
 from pipecatcloud._utils.console_utils import console
 from pipecatcloud._utils.regions import get_regions
+from pipecatcloud.cli.api import API
+from pipecatcloud.cli.config import config
 
 regions_cli = typer.Typer(name="regions", help="Region management", no_args_is_help=True)
 
@@ -71,3 +74,215 @@ async def list_regions():
         table.add_row(*row)
 
     console.print(table)
+
+
+# --- Self-hosted region lifecycle (PCC-1103) --------------------------------
+# Registration is an omit-preserves upsert: every option below is optional
+# except the region key, and omitted fields keep their stored values — so
+# re-running with one flag updates just that field.
+
+
+def _region_rows(region: dict) -> list[tuple[str, str]]:
+    """The full region record as label/value rows, stable order."""
+    archs = region.get("supported_architectures") or []
+    return [
+        ("Region key", str(region.get("region_key", ""))),
+        ("Display name", str(region.get("display_name") or "—")),
+        ("Enrollment status", str(region.get("enrollment_status", ""))),
+        ("Intermediate expires", str(region.get("intermediate_expires_at") or "—")),
+        ("WS public endpoint", str(region.get("ws_public_endpoint") or "—")),
+        ("Architectures", ", ".join(archs) if archs else "—"),
+        ("Default architecture", str(region.get("default_architecture") or "—")),
+        ("Workloads namespace", str(region.get("workloads_namespace") or "—")),
+    ]
+
+
+def _print_region(region: dict) -> None:
+    if console.json_output:
+        console.output_json({"region": region})
+        return
+    rows = _region_rows(region)
+    if not console.rich_output:
+        console.print_records(["Field", "Value"], rows)
+        return
+    table = Table(show_header=False)
+    table.add_column("Field", style="bold")
+    table.add_column("Value")
+    for label, value in rows:
+        table.add_row(label, value)
+    console.print(table)
+
+
+@regions_cli.command(
+    name="register",
+    help="Register or update a self-hosted region (omitted options are preserved)",
+)
+@synchronizer.create_blocking
+@requires_login
+async def register_region(
+    region_key: str = typer.Argument(..., help="The region's key, e.g. acme-us-east"),
+    workloads_namespace: str = typer.Option(
+        None,
+        "--workloads-namespace",
+        help="Customer-chosen namespace bot workloads run in (must match the install's global.workloadsNamespace)",
+    ),
+    architectures: str = typer.Option(
+        None,
+        "--architectures",
+        help="Comma-separated CPU architectures the cluster schedules, e.g. amd64,arm64. Only declare what it can actually run.",
+    ),
+    default_architecture: str = typer.Option(
+        None,
+        "--default-architecture",
+        help="Architecture deploys get when they don't declare one",
+    ),
+    ws_public_endpoint: str = typer.Option(
+        None,
+        "--ws-public-endpoint",
+        help="Public wss:// endpoint for WebSocket transports (omit for regions without a WS front door)",
+    ),
+    display_name: str = typer.Option(
+        None,
+        "--display-name",
+        help="Human-readable name shown in region pickers (without one, pickers show the uppercased key)",
+    ),
+    organization: str = typer.Option(None, "--organization", "-o"),
+):
+    org = organization or config.get("org")
+
+    # A region without a display name renders as its uppercased key in every
+    # picker — worth one interactive question, skippable with Enter (the
+    # upsert preserves whatever is stored).
+    if display_name is None and console.is_terminal:
+        answer = await questionary.text(
+            "Display name for region pickers (Enter to skip):"
+        ).ask_async()
+        if answer:
+            display_name = answer
+
+    payload: dict = {"regionKey": region_key}
+    if workloads_namespace is not None:
+        payload["workloadsNamespace"] = workloads_namespace
+    if architectures is not None:
+        payload["supportedArchitectures"] = [
+            a.strip() for a in architectures.split(",") if a.strip()
+        ]
+    if default_architecture is not None:
+        payload["defaultArchitecture"] = default_architecture
+    if ws_public_endpoint is not None:
+        payload["wsPublicEndpoint"] = ws_public_endpoint
+    if display_name is not None:
+        payload["displayName"] = display_name
+
+    with console.status(
+        f"[dim]Registering region [bold]'{region_key}'[/bold][/dim]", spinner="dots"
+    ):
+        region, error = await API.region_register(org=org, payload=payload)
+        if error:
+            raise typer.Exit(1)
+
+    if not console.json_output:
+        console.success(f"Region '{region_key}' registered")
+    _print_region(region or {})
+
+
+@regions_cli.command(name="show", help="Show a self-hosted region's full record")
+@synchronizer.create_blocking
+@requires_login
+async def show_region(
+    region_key: str = typer.Argument(..., help="The region's key"),
+    organization: str = typer.Option(None, "--organization", "-o"),
+):
+    org = organization or config.get("org")
+
+    with console.status(f"[dim]Fetching region [bold]'{region_key}'[/bold][/dim]", spinner="dots"):
+        region, error = await API.region_get(org=org, region_key=region_key)
+        if error:
+            raise typer.Exit(1)
+
+    if not region:
+        console.error(f"Region '{region_key}' not found in organization '{org}'")
+        raise typer.Exit(1)
+
+    _print_region(region)
+
+
+@regions_cli.command(
+    name="delete",
+    help="Revoke a self-hosted region (refused while it has live sessions or services)",
+)
+@synchronizer.create_blocking
+@requires_login
+async def delete_region(
+    region_key: str = typer.Argument(..., help="The region's key"),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Bypass the confirmation prompt AND the server's live-workload guard",
+    ),
+    organization: str = typer.Option(None, "--organization", "-o"),
+):
+    org = organization or config.get("org")
+
+    if not force:
+        console.require_interactive("--force")
+        if not await questionary.confirm(
+            f"Revoke region '{region_key}'? Its agent loses the control-plane "
+            "channel; the cluster itself is not touched. The server refuses "
+            "while the region has live sessions or deployed services."
+        ).ask_async():
+            console.print("[bold]Aborting delete request[/bold]")
+            raise typer.Exit(1)
+
+    with console.status(f"[dim]Revoking region [bold]'{region_key}'[/bold][/dim]", spinner="dots"):
+        # The 409 guard message (live session/service counts) is curated,
+        # customer-safe API copy — the error panel passes it through.
+        data, error = await API.region_delete(org=org, region_key=region_key, force=force)
+        if error:
+            raise typer.Exit(1)
+
+    if console.json_output:
+        console.output_json({"deleted": region_key, "result": data or {}})
+        return
+    console.success(f"Region '{region_key}' revoked")
+
+
+@regions_cli.command(
+    name="enroll-token",
+    help="Mint a one-time enrollment token for a self-hosted region",
+)
+@synchronizer.create_blocking
+@requires_login
+async def enroll_token(
+    region_key: str = typer.Argument(..., help="The region's key"),
+    organization: str = typer.Option(None, "--organization", "-o"),
+):
+    org = organization or config.get("org")
+
+    with console.status(
+        f"[dim]Minting enrollment token for [bold]'{region_key}'[/bold][/dim]",
+        spinner="dots",
+    ):
+        data, error = await API.region_enroll_token(org=org, region_key=region_key)
+        if error:
+            raise typer.Exit(1)
+
+    token = (data or {}).get("token")
+    if not token:
+        console.error("The API did not return a token")
+        raise typer.Exit(1)
+
+    kubectl_cmd = (
+        "kubectl -n pipecat-system create secret generic pipecat-region-enroll-token "
+        f"--from-literal=token={token}"
+    )
+    if console.json_output:
+        # Shown exactly once — stdout carries it, chrome goes to stderr.
+        console.output_json({"region": region_key, "token": token, "kubectlCommand": kubectl_cmd})
+        return
+    console.success(
+        f"One-time enrollment token minted for '{region_key}' — it cannot be retrieved again."
+    )
+    console.print("\nStage it in the cluster before the install:\n")
+    console.print(f"  {kubectl_cmd}\n", soft_wrap=True)

--- a/src/pipecatcloud/cli/commands/registry_keys.py
+++ b/src/pipecatcloud/cli/commands/registry_keys.py
@@ -46,6 +46,18 @@ async def mint_key(
 ):
     org = organization or config.get("org")
 
+    # The API requires a name — it's how keys are told apart in `list` and
+    # revoked safely. Prompt when interactive; otherwise require --name.
+    if name is None and console.is_terminal and not console.json_output:
+        answer = await questionary.text(
+            "Name for this key (e.g. acme-us-east-workstation):"
+        ).ask_async()
+        if answer and answer.strip():
+            name = answer.strip()
+    if not name:
+        console.error("A key name is required. Pass --name.")
+        raise typer.Exit(2)
+
     with console.status("[dim]Minting registry key...[/dim]", spinner="dots"):
         data, error = await API.registry_key_mint(org=org, name=name)
         if error:
@@ -88,7 +100,7 @@ async def list_keys(
         if error:
             raise typer.Exit(1)
 
-    keys = (data or {}).get("keys") or []
+    keys = (data or {}).get("registry_keys") or []
     if console.json_output:
         console.output_json({"keys": keys})
         return

--- a/src/pipecatcloud/cli/commands/registry_keys.py
+++ b/src/pipecatcloud/cli/commands/registry_keys.py
@@ -1,0 +1,149 @@
+#
+# Copyright (c) 2025, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Registry pull keys (PCC-1082/PCC-1103): org-scoped, pull-only credentials
+for fetching the region package chart from the Daily container registry.
+
+Org-scoped, so the group lives under `organizations` beside API keys — but a
+key's only consumer today is the self-hosted region install (the workstation
+`helm registry login` before pulling the pcc-region chart). The key material
+is shown exactly once, at mint; the cluster's own image-pull credential is
+delivered by enrollment and never passes through here.
+"""
+
+import questionary
+import typer
+from rich.table import Table
+
+from pipecatcloud._utils.async_utils import synchronizer
+from pipecatcloud._utils.auth_utils import requires_login
+from pipecatcloud._utils.console_utils import console
+from pipecatcloud.cli.api import API
+from pipecatcloud.cli.config import config
+
+PROD_REGISTRY_HOST = "registry.pipecat.daily.co"
+
+registry_keys_cli = typer.Typer(
+    name="registry-keys",
+    help="Registry pull keys for fetching the region package chart",
+    no_args_is_help=True,
+)
+
+
+@registry_keys_cli.command(name="mint", help="Mint a registry pull key (shown exactly once)")
+@synchronizer.create_blocking
+@requires_login
+async def mint_key(
+    name: str = typer.Option(
+        None,
+        "--name",
+        help="Human label for the key, e.g. acme-us-east-workstation",
+    ),
+    organization: str = typer.Option(None, "--organization", "-o"),
+):
+    org = organization or config.get("org")
+
+    with console.status("[dim]Minting registry key...[/dim]", spinner="dots"):
+        data, error = await API.registry_key_mint(org=org, name=name)
+        if error:
+            raise typer.Exit(1)
+
+    key = (data or {}).get("key")
+    if not key:
+        console.error("The API did not return a key")
+        raise typer.Exit(1)
+
+    username = data.get("username", "pcc")
+    login_cmd = f"helm registry login {PROD_REGISTRY_HOST} -u {username} -p {key}"
+    if console.json_output:
+        # Shown exactly once — stdout carries it, chrome goes to stderr.
+        console.output_json(
+            {
+                "id": data.get("id"),
+                "name": data.get("name"),
+                "key": key,
+                "username": username,
+                "helmLoginCommand": login_cmd,
+            }
+        )
+        return
+    console.success("Registry key minted — it is shown ONCE and cannot be retrieved again.")
+    console.print("\nLog your workstation's helm in before pulling the chart:\n")
+    console.print(f"  {login_cmd}\n", soft_wrap=True)
+
+
+@registry_keys_cli.command(name="list", help="List registry keys (no key material)")
+@synchronizer.create_blocking
+@requires_login
+async def list_keys(
+    organization: str = typer.Option(None, "--organization", "-o"),
+):
+    org = organization or config.get("org")
+
+    with console.status("[dim]Fetching registry keys...[/dim]", spinner="dots"):
+        data, error = await API.registry_keys(org=org)
+        if error:
+            raise typer.Exit(1)
+
+    keys = (data or {}).get("keys") or []
+    if console.json_output:
+        console.output_json({"keys": keys})
+        return
+    if not keys:
+        console.print("[yellow]No registry keys[/yellow]")
+        return
+
+    headers = ["ID", "Name", "Prefix", "Created", "Last used", "Revoked"]
+    rows = [
+        (
+            str(k.get("id", "")),
+            str(k.get("name") or "—"),
+            str(k.get("key_prefix") or "—"),
+            str(k.get("created_at") or "—"),
+            str(k.get("last_used_at") or "—"),
+            "yes" if k.get("revoked") else "no",
+        )
+        for k in keys
+    ]
+    if not console.rich_output:
+        console.print_records(headers, rows)
+        return
+    table = Table(show_header=True, header_style="bold")
+    for h in headers:
+        table.add_column(h)
+    for row in rows:
+        table.add_row(*row)
+    console.print(table)
+
+
+@registry_keys_cli.command(name="revoke", help="Revoke a registry key")
+@synchronizer.create_blocking
+@requires_login
+async def revoke_key(
+    key_id: str = typer.Argument(..., help="The key's id (see list)"),
+    force: bool = typer.Option(False, "--force", "-f", help="Bypass prompt for confirmation"),
+    organization: str = typer.Option(None, "--organization", "-o"),
+):
+    org = organization or config.get("org")
+
+    if not force:
+        console.require_interactive("--force")
+        if not await questionary.confirm(
+            "Revoke this registry key? Workstations using it lose chart-pull "
+            "access immediately; enrolled clusters are unaffected."
+        ).ask_async():
+            console.print("[bold]Aborting revoke request[/bold]")
+            raise typer.Exit(1)
+
+    with console.status("[dim]Revoking registry key...[/dim]", spinner="dots"):
+        _, error = await API.registry_key_revoke(org=org, key_id=key_id)
+        if error:
+            raise typer.Exit(1)
+
+    if console.json_output:
+        console.output_json({"revoked": key_id})
+        return
+    console.success("Registry key revoked")

--- a/src/pipecatcloud/config.py
+++ b/src/pipecatcloud/config.py
@@ -37,6 +37,7 @@ _SETTINGS = {
     "api_keys_path": _Setting("/v1/organizations/{org}/apiKeys"),
     "secrets_path": _Setting("/v1/organizations/{org}/secrets"),
     "regions_path": _Setting("/v1/organizations/{org}/regions"),
+    "registry_keys_path": _Setting("/v1/organizations/{org}/registry-keys"),
     "agent_profiles_path": _Setting("/v1/organizations/{org}/agent-profiles"),
     "properties_path": _Setting("/v1/organizations/{org}/properties"),
     "spend_limit_path": _Setting("/v1/organizations/{org}/spend-limit"),

--- a/tests/test_regions_lifecycle.py
+++ b/tests/test_regions_lifecycle.py
@@ -25,7 +25,7 @@ from pipecatcloud.cli.commands.regions import (
     register_region,
     show_region,
 )
-from pipecatcloud.cli.commands.registry_keys import mint_key, registry_keys_cli
+from pipecatcloud.cli.commands.registry_keys import list_keys, mint_key, registry_keys_cli
 
 
 @pytest.fixture
@@ -170,6 +170,67 @@ async def test_registry_key_mint_reaches_json_output():
         assert out["key"] == "pcc_reg_abc"
         assert "pcc_reg_abc" in out["helmLoginCommand"]
         assert "registry.pipecat.daily.co" in out["helmLoginCommand"]
+
+
+@pytest.mark.asyncio
+async def test_registry_key_list_reads_registry_keys_envelope():
+    """The API's list envelope is `registry_keys`, not `keys` — reading the
+    wrong field renders every org as having no keys (cli#192 review)."""
+    with (
+        patch("pipecatcloud.cli.commands.registry_keys.API") as mock_api,
+        patch("pipecatcloud.cli.commands.registry_keys.console") as mock_console,
+    ):
+        mock_console.json_output = True
+        mock_api.registry_keys = AsyncMock(
+            return_value=({"registry_keys": [{"id": "k1", "name": "ws"}]}, None)
+        )
+
+        await list_keys.aio(organization=None)
+
+        out = mock_console.output_json.call_args.args[0]
+        assert out["keys"] == [{"id": "k1", "name": "ws"}]
+
+
+@pytest.mark.asyncio
+async def test_registry_key_mint_requires_name_when_noninteractive():
+    """The API's mint schema requires a name; without a terminal to prompt in,
+    the CLI must exit 2 before the request instead of collecting a 400."""
+    with (
+        patch("pipecatcloud.cli.commands.registry_keys.API") as mock_api,
+        patch("pipecatcloud.cli.commands.registry_keys.console") as mock_console,
+    ):
+        mock_console.is_terminal = False
+        mock_console.json_output = False
+        mock_api.registry_key_mint = AsyncMock()
+
+        with pytest.raises(typer.Exit) as excinfo:
+            await mint_key.aio(name=None, organization=None)
+        assert excinfo.value.exit_code == 2
+        mock_api.registry_key_mint.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_register_does_not_prompt_in_json_mode(region_mocks):
+    """`--output json` from a terminal is a scripting context: the display-name
+    question must not interrupt it (cli#192 review)."""
+    mock_api, mock_console = region_mocks
+    mock_console.is_terminal = True
+    mock_console.json_output = True
+    mock_api.region_register = AsyncMock(return_value=({}, None))
+
+    with patch("pipecatcloud.cli.commands.regions.questionary") as mock_questionary:
+        await register_region.aio(
+            "acme",
+            workloads_namespace=None,
+            architectures=None,
+            default_architecture=None,
+            ws_public_endpoint=None,
+            display_name=None,
+            organization=None,
+        )
+
+    mock_questionary.text.assert_not_called()
+    assert "displayName" not in mock_api.region_register.await_args.kwargs["payload"]
 
 
 def test_existing_regions_commands_untouched():

--- a/tests/test_regions_lifecycle.py
+++ b/tests/test_regions_lifecycle.py
@@ -1,0 +1,181 @@
+"""Tests for the self-hosted region lifecycle verbs (PCC-1103):
+`regions register/show/delete/enroll-token` and
+`organizations registry-keys mint/list/revoke`.
+
+Pins the load-bearing properties: omit-preserves registration payloads (only
+what the caller passed goes on the wire), show-once values reaching JSON
+output, real non-zero exits on API errors, and the non-interactive guard on
+destructive verbs.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import typer
+
+# Import from source, not installed package
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from pipecatcloud.cli.commands.regions import (
+    delete_region,
+    enroll_token,
+    regions_cli,
+    register_region,
+    show_region,
+)
+from pipecatcloud.cli.commands.registry_keys import mint_key, registry_keys_cli
+
+
+@pytest.fixture
+def region_mocks():
+    with (
+        patch("pipecatcloud.cli.commands.regions.API") as mock_api,
+        patch("pipecatcloud.cli.commands.regions.console") as mock_console,
+    ):
+        mock_console.is_terminal = False
+        mock_console.json_output = False
+        mock_console.rich_output = False
+        yield mock_api, mock_console
+
+
+@pytest.mark.asyncio
+async def test_register_sends_only_provided_fields(region_mocks):
+    """Omit-preserves: absent options must be absent from the payload, or a
+    partial re-register would clobber stored fields with nulls."""
+    mock_api, _ = region_mocks
+    mock_api.region_register = AsyncMock(return_value=({"region_key": "acme"}, None))
+
+    await register_region.aio(
+        "acme",
+        workloads_namespace=None,
+        architectures=None,
+        default_architecture=None,
+        ws_public_endpoint="wss://ws.acme.example",
+        display_name=None,
+        organization=None,
+    )
+
+    payload = mock_api.region_register.await_args.kwargs["payload"]
+    assert payload == {
+        "regionKey": "acme",
+        "wsPublicEndpoint": "wss://ws.acme.example",
+    }
+
+
+@pytest.mark.asyncio
+async def test_register_splits_architectures(region_mocks):
+    mock_api, _ = region_mocks
+    mock_api.region_register = AsyncMock(return_value=({}, None))
+
+    await register_region.aio(
+        "acme",
+        workloads_namespace=None,
+        architectures=" amd64, arm64 ",
+        default_architecture="amd64",
+        ws_public_endpoint=None,
+        display_name=None,
+        organization=None,
+    )
+
+    payload = mock_api.region_register.await_args.kwargs["payload"]
+    assert payload["supportedArchitectures"] == ["amd64", "arm64"]
+    assert payload["defaultArchitecture"] == "amd64"
+
+
+@pytest.mark.asyncio
+async def test_register_api_error_exits_nonzero(region_mocks):
+    mock_api, _ = region_mocks
+    mock_api.region_register = AsyncMock(return_value=(None, {"error": "nope"}))
+
+    with pytest.raises(typer.Exit) as excinfo:
+        await register_region.aio(
+            "acme",
+            workloads_namespace=None,
+            architectures=None,
+            default_architecture=None,
+            ws_public_endpoint=None,
+            display_name=None,
+            organization=None,
+        )
+    assert excinfo.value.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_show_unknown_region_exits_nonzero(region_mocks):
+    mock_api, _ = region_mocks
+    mock_api.region_get = AsyncMock(return_value=(None, None))
+
+    with pytest.raises(typer.Exit) as excinfo:
+        await show_region.aio("ghost", organization=None)
+    assert excinfo.value.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_without_force_requires_interactive(region_mocks):
+    """Non-interactive + no --force must fail fast (exit 2 via
+    require_interactive), never hang on a prompt (PCC-1064 rules)."""
+    _, mock_console = region_mocks
+    mock_console.require_interactive.side_effect = typer.Exit(2)
+
+    with pytest.raises(typer.Exit) as excinfo:
+        await delete_region.aio("acme", force=False, organization=None)
+    assert excinfo.value.exit_code == 2
+    mock_console.require_interactive.assert_called_once_with("--force")
+
+
+@pytest.mark.asyncio
+async def test_delete_force_passes_force_to_api(region_mocks):
+    mock_api, _ = region_mocks
+    mock_api.region_delete = AsyncMock(return_value=({}, None))
+
+    await delete_region.aio("acme", force=True, organization=None)
+
+    kwargs = mock_api.region_delete.await_args.kwargs
+    assert kwargs["force"] is True
+    assert kwargs["region_key"] == "acme"
+
+
+@pytest.mark.asyncio
+async def test_enroll_token_reaches_json_output(region_mocks):
+    """The one-time token is shown once: it must land in the JSON payload
+    together with the ready-to-paste kubectl command."""
+    mock_api, mock_console = region_mocks
+    mock_console.json_output = True
+    mock_api.region_enroll_token = AsyncMock(return_value=({"token": "tok-123"}, None))
+
+    await enroll_token.aio("acme", organization=None)
+
+    out = mock_console.output_json.call_args.args[0]
+    assert out["token"] == "tok-123"
+    assert "tok-123" in out["kubectlCommand"]
+    assert "pipecat-region-enroll-token" in out["kubectlCommand"]
+
+
+@pytest.mark.asyncio
+async def test_registry_key_mint_reaches_json_output():
+    with (
+        patch("pipecatcloud.cli.commands.registry_keys.API") as mock_api,
+        patch("pipecatcloud.cli.commands.registry_keys.console") as mock_console,
+    ):
+        mock_console.json_output = True
+        mock_api.registry_key_mint = AsyncMock(
+            return_value=({"id": "k1", "name": "ws", "key": "pcc_reg_abc", "username": "pcc"}, None)
+        )
+
+        await mint_key.aio(name="ws", organization=None)
+
+        out = mock_console.output_json.call_args.args[0]
+        assert out["key"] == "pcc_reg_abc"
+        assert "pcc_reg_abc" in out["helmLoginCommand"]
+        assert "registry.pipecat.daily.co" in out["helmLoginCommand"]
+
+
+def test_existing_regions_commands_untouched():
+    """The new verbs are additive: `list` survives, and the lifecycle verbs
+    are registered under the expected names."""
+    names = {cmd.name for cmd in regions_cli.registered_commands}
+    assert {"list", "register", "show", "delete", "enroll-token"} <= names
+    rk_names = {cmd.name for cmd in registry_keys_cli.registered_commands}
+    assert rk_names == {"mint", "list", "revoke"}


### PR DESCRIPTION
Closes [PCC-1103](https://linear.app/dailyco/issue/PCC-1103). The control-plane half of a self-hosted region's setup, with no raw API calls — the jumpstart runbook's steps 5–6 collapse from four curls to two commands.

## Commands

**`pipecat cloud regions …`**
- `register <key>` — owner-declared upsert (`--workloads-namespace`, `--architectures amd64,arm64`, `--default-architecture`, `--ws-public-endpoint`, `--display-name`). **Omit-preserves**: options you don't pass keep their stored values (help text says so). Interactive-only display-name prompt, skippable with Enter — a region without one renders as its uppercased key in every picker (hit live on the dashboard yesterday).
- `show <key>` — the full record via `GET /regions/{key}`: enrollment status, **intermediate certificate expiry** (previously invisible anywhere), ws endpoint, architectures, namespace.
- `delete <key>` — confirmation-gated; the server's 409 live-workload refusal passes through (curated copy); `--force` maps to `?force=true`; non-TTY without `--force` fails fast exit 2 per the PCC-1064 rules.
- `enroll-token <key>` — mints the one-time token and prints the ready-to-paste `kubectl create secret` line. In `--output json` the token + command land on stdout, chrome on stderr.

**`pipecat cloud organizations registry-keys …`** — `mint` / `list` / `revoke`. Placed under `organizations` (org-scoped, beside API keys) per the Slack thread with Brian: semantically correct, and nesting under `regions` would age badly if the registry concept grows. Mint prints the matching `helm registry login` line and the key exactly once; list shows lifecycle metadata only.

## Notes

- API-client methods follow the existing `_method` + `create_api_method` property pattern; routes verified against the live prod API (`GET /regions/{key}` exists and carries the full record — the org regions list is the slim picker shape).
- All output honors the merged PCC-1064 modes (rich/plain/json, real exit codes).

## Tests

9 new: omit-preserves payload construction, architecture list parsing, error exit codes, non-interactive delete guard (exit 2), show-once token + registry key reaching JSON output with their paste-ready commands, additive command-registry pin. 334 total green; ruff clean; pyright net-zero vs main.

## Acceptance (per ticket)

Next step after merge: rewrite jumpstart steps 5–6 to the CLI shape and verify `regions register`/`enroll-token` against `ms-dev-us-west-2` on prod (re-register is an idempotent upsert, so the live region is a safe target).
