### PR TITLE
Add --architecture to deploy, pre-validated per region (PCC-1105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   built for one architecture, so it schedules on matching nodes instead of
   failing at startup. The choice is validated against the target region's
   supported architectures before anything uploads, when the API advertises
-  them. `pipecat cloud agent status` shows the deployment's architecture.
+  them. `pipecat cloud regions list` shows each region's supported and
+  default architectures (Daily-hosted regions are arm64-only today), and
+  `pipecat cloud agent status` shows the deployment's architecture.
 
 - Explicit agent sizing for **enterprise (self-hosted) regions**. Deploys can
   now state resources directly instead of selecting an agent profile:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Architecture selection on deploy: `pipecat cloud deploy --architecture
+  {amd64,arm64}` or an `architecture` key in `pcc-deploy.toml` (the flag
+  wins). Omitted, the region's default applies — set it when your image is
+  built for one architecture, so it schedules on matching nodes instead of
+  failing at startup. The choice is validated against the target region's
+  supported architectures before anything uploads, when the API advertises
+  them. `pipecat cloud agent status` shows the deployment's architecture.
+
 - Explicit agent sizing for **enterprise (self-hosted) regions**. Deploys can
   now state resources directly instead of selecting an agent profile:
   `pipecat cloud deploy --resources cpu=2,memory=4Gi`, or a `[resources]`

--- a/src/pipecatcloud/_utils/deploy_utils.py
+++ b/src/pipecatcloud/_utils/deploy_utils.py
@@ -394,6 +394,9 @@ class DeployConfigParams:
     force_redeploy: bool = False
     websocket_auth: str | None = None
     max_session_duration: int | None = None
+    # CPU architecture the agent image requires (PCC-1105). Exactly the
+    # kubernetes.io/arch vocabulary; omitted = the region's default.
+    architecture: str | None = None
 
     def __attrs_post_init__(self):
         if self.image is not None and ":" not in self.image:
@@ -407,6 +410,8 @@ class DeployConfigParams:
         # regions). The API enforces this too; failing here is just faster.
         if self.agent_profile is not None and self.resources.is_set():
             raise ValueError("Cannot specify both 'agent_profile' and 'resources'")
+        if self.architecture is not None and self.architecture not in ("amd64", "arm64"):
+            raise ValueError("architecture must be 'amd64' or 'arm64'")
 
     def to_dict(self):
         return {
@@ -424,6 +429,7 @@ class DeployConfigParams:
             "krisp_viva": self.krisp_viva.to_dict() if self.krisp_viva else None,
             "websocket_auth": self.websocket_auth,
             "max_session_duration": self.max_session_duration,
+            "architecture": self.architecture,
         }
 
 
@@ -481,6 +487,7 @@ def load_deploy_config_file() -> DeployConfigParams | None:
             "websocket_auth",
             "max_session_duration",
             "resources",
+            "architecture",
         }
 
         # TODO: Remove this enable_krisp migration hint in the 2.0.0 release.

--- a/src/pipecatcloud/_utils/regions.py
+++ b/src/pipecatcloud/_utils/regions.py
@@ -66,3 +66,24 @@ async def validate_region(region: str) -> bool:
     """
     valid_codes = await get_region_codes()
     return region in valid_codes
+
+
+def validate_architecture_for_region(
+    architecture: str, region: str, regions: list[dict]
+) -> str | None:
+    """Pre-validate an architecture choice against a region's capability
+    (PCC-1105). Returns an error message, or None when the choice is valid
+    or cannot be checked locally.
+
+    The regions payload carries ``supported_architectures`` only on newer
+    APIs — when absent, defer to the server's own validation (its 400 names
+    the supported list).
+    """
+    entry = next((r for r in regions if r.get("code") == region), None)
+    supported = (entry or {}).get("supported_architectures")
+    if not supported or architecture in supported:
+        return None
+    return (
+        f"Architecture '{architecture}' is not supported in region '{region}' "
+        f"(supported: {', '.join(supported)})"
+    )

--- a/src/pipecatcloud/api.py
+++ b/src/pipecatcloud/api.py
@@ -560,6 +560,10 @@ class _API:
             "forceRedeploy": deploy_config.force_redeploy or None,
             "websocketAuth": deploy_config.websocket_auth,
             "maxSessionDuration": deploy_config.max_session_duration,
+            # The field name is `architecture` — the API silently drops
+            # unknown keys, so a wrong name here schedules on the region
+            # default and exec-format-errors (the PCC-1105 incident).
+            "architecture": deploy_config.architecture,
         }
 
         # Use either build_id (cloud build) or image (user-provided)

--- a/src/pipecatcloud/cli/commands/agent.py
+++ b/src/pipecatcloud/cli/commands/agent.py
@@ -272,6 +272,15 @@ async def status(
                 str(agent_profile),
             )
 
+        # The architecture the deployment pinned (PCC-1105) — which nodes it
+        # schedules on and which image platform was resolved.
+        arch = data.get("deployment", {}).get("manifest", {}).get("spec", {}).get("arch")
+        if arch:
+            deployment_table.add_row(
+                "[bold]Architecture:[/bold]",
+                str(arch),
+            )
+
         # Resolved sizing from the deployment manifest. For an agent deployed
         # with explicit resources (enterprise regions), there is no profile —
         # this row is its only visible sizing.

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -36,7 +36,12 @@ from pipecatcloud._utils.deploy_utils import (
     parse_resources_option,
     with_deploy_config,
 )
-from pipecatcloud._utils.regions import get_region_codes, validate_region
+from pipecatcloud._utils.regions import (
+    get_region_codes,
+    get_regions,
+    validate_architecture_for_region,
+    validate_region,
+)
 from pipecatcloud.cli import PIPECAT_CLI_NAME
 from pipecatcloud.cli.api import API
 from pipecatcloud.cli.config import config
@@ -631,6 +636,16 @@ def create_deploy_command(app: typer.Typer):
             help="Region for service deployment",
             rich_help_panel="Deployment Configuration",
         ),
+        architecture: str = typer.Option(
+            None,
+            "--architecture",
+            help=(
+                "CPU architecture the agent image requires (amd64 or arm64). "
+                "Omitted, the region's default applies. Must match how the "
+                "image was built."
+            ),
+            rich_help_panel="Deployment Configuration",
+        ),
         max_session_duration: int | None = typer.Option(
             None,
             "--max-session-duration",
@@ -750,6 +765,27 @@ def create_deploy_command(app: typer.Typer):
                 f"Invalid region '{deploy_region}'. Valid regions are: {', '.join(valid_regions)}"
             )
             raise typer.Exit(1)
+
+        # Architecture (PCC-1105): flag beats toml; vocabulary is exactly
+        # kubernetes.io/arch. Pre-validate against the region's capability
+        # when the regions payload carries it — a deploy-time error here
+        # beats an exec-format crashloop; older APIs defer to the server's
+        # own 400, which names the supported list.
+        partial_config.architecture = architecture or partial_config.architecture
+        if partial_config.architecture is not None:
+            if partial_config.architecture not in ("amd64", "arm64"):
+                console.error(
+                    f"Invalid architecture '{partial_config.architecture}'. "
+                    "Valid values are: amd64, arm64"
+                )
+                raise typer.Exit(1)
+            if deploy_region:
+                arch_error = validate_architecture_for_region(
+                    partial_config.architecture, deploy_region, await get_regions()
+                )
+                if arch_error:
+                    console.error(arch_error)
+                    raise typer.Exit(1)
 
         # Handle Krisp VIVA configuration
         if krisp_viva_audio_filter is not None:

--- a/src/pipecatcloud/cli/commands/deploy.py
+++ b/src/pipecatcloud/cli/commands/deploy.py
@@ -641,8 +641,9 @@ def create_deploy_command(app: typer.Typer):
             "--architecture",
             help=(
                 "CPU architecture the agent image requires (amd64 or arm64). "
-                "Omitted, the region's default applies. Must match how the "
-                "image was built."
+                "Omitted, the region's default applies. Regions support "
+                "specific architectures — see 'regions list'. Must match how "
+                "the image was built."
             ),
             rich_help_panel="Deployment Configuration",
         ),

--- a/src/pipecatcloud/cli/commands/regions.py
+++ b/src/pipecatcloud/cli/commands/regions.py
@@ -34,19 +34,40 @@ async def list_regions():
         console.print("[yellow]No regions available[/yellow]")
         return
 
-    rows = [(region["code"], region["display_name"]) for region in regions]
+    # Architecture capability (PCC-1105): what --architecture may name per
+    # region — e.g. Daily-hosted regions are arm64-only today, which is
+    # data here, never an assumption baked into the CLI. Older APIs omit
+    # the fields; render a dash rather than guessing.
+    def arch_cell(region: dict) -> str:
+        supported = region.get("supported_architectures")
+        return ", ".join(supported) if supported else "—"
+
+    def default_cell(region: dict) -> str:
+        return region.get("default_architecture") or "—"
+
+    rows = [
+        (
+            region["code"],
+            region["display_name"],
+            arch_cell(region),
+            default_cell(region),
+        )
+        for region in regions
+    ]
 
     if not console.rich_output:
-        console.print_records(["Code", "Name"], rows)
+        console.print_records(["Code", "Name", "Architectures", "Default"], rows)
         return
 
     # Create table
     table = Table(show_header=True, header_style="bold")
     table.add_column("Code")
     table.add_column("Name")
+    table.add_column("Architectures")
+    table.add_column("Default")
 
     # Add rows
-    for code, name in rows:
-        table.add_row(code, name)
+    for row in rows:
+        table.add_row(*row)
 
     console.print(table)

--- a/tests/test_deploy_architecture.py
+++ b/tests/test_deploy_architecture.py
@@ -1,0 +1,63 @@
+"""Architecture selection on deploy (PCC-1105): config validation, the
+omit-preserving payload field, and region-capability pre-validation."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from pipecatcloud._utils.deploy_utils import DeployConfigParams
+from pipecatcloud._utils.regions import validate_architecture_for_region
+
+
+def test_config_accepts_valid_architecture():
+    cfg = DeployConfigParams(architecture="arm64")
+    assert cfg.to_dict()["architecture"] == "arm64"
+
+
+def test_config_defaults_to_no_architecture():
+    assert DeployConfigParams().to_dict()["architecture"] is None
+
+
+def test_config_rejects_invalid_architecture():
+    # kubernetes.io/arch vocabulary only — never arm/amd.
+    with pytest.raises(ValueError, match="amd64"):
+        DeployConfigParams(architecture="arm")
+
+
+REGIONS = [
+    {"code": "us-west", "display_name": "US West"},  # old API: no capability
+    {
+        "code": "ms-dev",
+        "display_name": "MS Dev",
+        "supported_architectures": ["amd64", "arm64"],
+        "default_architecture": "amd64",
+    },
+    {
+        "code": "cloud-arm",
+        "display_name": "Cloud",
+        "supported_architectures": ["arm64"],
+        "default_architecture": "arm64",
+    },
+]
+
+
+def test_prevalidation_passes_supported_choice():
+    assert validate_architecture_for_region("arm64", "ms-dev", REGIONS) is None
+
+
+def test_prevalidation_rejects_unsupported_choice():
+    error = validate_architecture_for_region("amd64", "cloud-arm", REGIONS)
+    assert error is not None
+    assert "amd64" in error and "cloud-arm" in error and "arm64" in error
+
+
+def test_prevalidation_defers_when_capability_absent():
+    # Older API payloads carry no capability — the server's own 400 decides.
+    assert validate_architecture_for_region("amd64", "us-west", REGIONS) is None
+
+
+def test_prevalidation_defers_for_unknown_region():
+    assert validate_architecture_for_region("amd64", "ghost", REGIONS) is None


### PR DESCRIPTION
Second of three PRs for [PCC-1105](https://linear.app/dailyco/issue/PCC-1105) (enabler: sandbox#750; dashboard half next). Order-independent: without the serializer fields the pre-validation defers to the server's curated 400.

## What

- `pipecat cloud deploy --architecture {amd64,arm64}` + `architecture` key in `pcc-deploy.toml` (flag wins). Omitted → the region's default, exactly as today.
- **Region-aware pre-validation**: when the regions payload carries `supported_architectures` (sandbox#750), a bad choice fails before anything uploads, with the supported list named. Older APIs: the server's own 400 passes through. Unknown-region/absent-capability cases defer rather than guess.
- `agent status` gains an Architecture row (from the deployment manifest's `spec.arch`).
- Config-level validation rejects non-`kubernetes.io/arch` vocabulary (`arm`/`amd` never accepted — those live only in the deprecated nodeType shim).

Motivating incident (2026-08-13): deploying an arm-only image to a default-amd64 region required knowing the raw API field name, and a typo'd `arch:` was silently dropped → exec-format crashloop. The payload comment now warns about exactly that.

## Tests

7 new: config accepts/defaults/rejects, pre-validation passes/rejects (message names region + supported list)/defers on absent capability/defers on unknown region. 332 total green; ruff clean; pyright 49 errors vs 52 on the unmodified branch (net −3).
